### PR TITLE
[Thien] Create PostgrestResponse class and PostgrestError class 🥳

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -13,9 +13,9 @@ void main(List<String> arguments) async {
       .from('countries')
       .select('*')
       .order('name', {'ascending': true}).end();
-  if (response['statusCode'] == 200) {
-    print('Countries List: ${response['body']}.');
+  if (response.status == 200) {
+    print('Countries List: ${response.body}.');
   } else {
-    print('Request failed with status: ${response['statusCode']}.');
+    print('Request failed with status: ${response.status}.');
   }
 }

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:core';
 
 import 'package:http/http.dart' as http;
+import 'package:postgrest/models/postgrest_error.dart';
+import 'package:postgrest/models/postgrest_response.dart';
 
 /// The base builder class.
 class PostgrestBuilder {
@@ -18,7 +20,7 @@ class PostgrestBuilder {
   ///
   /// For more details about switching schemas: https://postgrest.org/en/stable/api.html#switching-schemas
   /// Returns {Future} Resolves when the request has completed.
-  Future<Map<String, dynamic>> end() async {
+  Future<PostgrestResponse> end() async {
     try {
       var uppercaseMethod = method.toUpperCase();
       var response;
@@ -52,25 +54,25 @@ class PostgrestBuilder {
 
       return parseJsonResponse(response);
     } catch (e) {
-      return {
-        'body': null,
-        'status': 500,
-        'statusCode': e.runtimeType.toString(),
-        'statusText': e.toString()
-      };
+      return PostgrestResponse(
+        body: null,
+        status: 500,
+        error: PostgrestError(code: e.runtimeType.toString()),
+        statusText: e.toString(),
+      );
     }
   }
 
   /// Parse request response to json object if possible
-  Map<String, dynamic> parseJsonResponse(dynamic response) {
+  PostgrestResponse parseJsonResponse(dynamic response) {
     if (response.statusCode >= 400) {
       // error handling
-      return {
-        'body': null,
-        'status': response.statusCode,
-        'statusCode': response.statusCode,
-        'statusText': response.body.toString(),
-      };
+      return PostgrestResponse(
+        body: null,
+        status: response.statusCode,
+        error: PostgrestError(code: response.statusCode.toString()),
+        statusText: response.body.toString(),
+      );
     } else {
       var body;
       try {
@@ -79,12 +81,12 @@ class PostgrestBuilder {
         body = response.body;
       }
 
-      return {
-        'body': body,
-        'status': response.statusCode,
-        'statusCode': response.statusCode,
-        'statusText': null,
-      };
+      return PostgrestResponse(
+        body: body,
+        status: response.statusCode,
+        error: null,
+        statusText: null,
+      );
     }
   }
 

--- a/lib/models/postgrest_error.dart
+++ b/lib/models/postgrest_error.dart
@@ -1,8 +1,10 @@
-// To parse this JSON data, do
-//
-//     final postgrestError = postgrestErrorFromJson(jsonString);
+/// To parse this JSON data, do
+///
+///     final postgrestError = postgrestErrorFromJson(jsonString);
 
 import 'dart:convert';
+
+PostgrestError postgrestErrorFromJson(String str) => PostgrestError.fromJson(json.decode(str));
 
 class PostgrestError {
   PostgrestError({
@@ -16,24 +18,6 @@ class PostgrestError {
   String details;
   String hint;
   String code;
-
-  PostgrestError copyWith({
-    String message,
-    String details,
-    String hint,
-    String code,
-  }) =>
-      PostgrestError(
-        message: message ?? this.message,
-        details: details ?? this.details,
-        hint: hint ?? this.hint,
-        code: code ?? this.code,
-      );
-
-  factory PostgrestError.fromRawJson(String str) =>
-      PostgrestError.fromJson(json.decode(str));
-
-  String toRawJson() => json.encode(toJson());
 
   factory PostgrestError.fromJson(Map<String, dynamic> json) => PostgrestError(
         message: json['message'],

--- a/lib/models/postgrest_error.dart
+++ b/lib/models/postgrest_error.dart
@@ -1,0 +1,51 @@
+// To parse this JSON data, do
+//
+//     final postgrestError = postgrestErrorFromJson(jsonString);
+
+import 'dart:convert';
+
+class PostgrestError {
+  PostgrestError({
+    this.message,
+    this.details,
+    this.hint,
+    this.code,
+  });
+
+  String message;
+  String details;
+  String hint;
+  String code;
+
+  PostgrestError copyWith({
+    String message,
+    String details,
+    String hint,
+    String code,
+  }) =>
+      PostgrestError(
+        message: message ?? this.message,
+        details: details ?? this.details,
+        hint: hint ?? this.hint,
+        code: code ?? this.code,
+      );
+
+  factory PostgrestError.fromRawJson(String str) =>
+      PostgrestError.fromJson(json.decode(str));
+
+  String toRawJson() => json.encode(toJson());
+
+  factory PostgrestError.fromJson(Map<String, dynamic> json) => PostgrestError(
+        message: json['message'],
+        details: json['details'],
+        hint: json['hint'],
+        code: json['code'],
+      );
+
+  Map<String, dynamic> toJson() => {
+        'message': message,
+        'details': details,
+        'hint': hint,
+        'code': code,
+      };
+}

--- a/lib/models/postgrest_response.dart
+++ b/lib/models/postgrest_response.dart
@@ -1,10 +1,12 @@
-// To parse this JSON data, do
-//
-//     final postgrestResponse = postgrestResponseFromJson(jsonString);
+/// To parse this JSON data, do
+///
+///     final postgrestResponse = postgrestResponseFromJson(jsonString);
 
 import 'dart:convert';
 
 import 'package:postgrest/models/postgrest_error.dart';
+
+PostgrestResponse postgrestResponseFromJson(String str) => PostgrestResponse.fromJson(json.decode(str));
 
 class PostgrestResponse {
   PostgrestResponse({
@@ -18,25 +20,6 @@ class PostgrestResponse {
   int status;
   String statusText;
   PostgrestError error;
-
-  PostgrestResponse copyWith({
-    dynamic body,
-    int status,
-    int statusCode,
-    String statusText,
-    PostgrestError error,
-  }) =>
-      PostgrestResponse(
-        body: body ?? this.body,
-        status: status ?? this.status,
-        statusText: statusText ?? this.statusText,
-        error: error ?? this.error,
-      );
-
-  factory PostgrestResponse.fromRawJson(String str) =>
-      PostgrestResponse.fromJson(json.decode(str));
-
-  String toRawJson() => json.encode(toJson());
 
   factory PostgrestResponse.fromJson(Map<String, dynamic> json) =>
       PostgrestResponse(

--- a/lib/models/postgrest_response.dart
+++ b/lib/models/postgrest_response.dart
@@ -1,0 +1,57 @@
+// To parse this JSON data, do
+//
+//     final postgrestResponse = postgrestResponseFromJson(jsonString);
+
+import 'dart:convert';
+
+import 'package:postgrest/models/postgrest_error.dart';
+
+class PostgrestResponse {
+  PostgrestResponse({
+    this.body,
+    this.status,
+    this.statusText,
+    this.error,
+  });
+
+  dynamic body;
+  int status;
+  String statusText;
+  PostgrestError error;
+
+  PostgrestResponse copyWith({
+    dynamic body,
+    int status,
+    int statusCode,
+    String statusText,
+    PostgrestError error,
+  }) =>
+      PostgrestResponse(
+        body: body ?? this.body,
+        status: status ?? this.status,
+        statusText: statusText ?? this.statusText,
+        error: error ?? this.error,
+      );
+
+  factory PostgrestResponse.fromRawJson(String str) =>
+      PostgrestResponse.fromJson(json.decode(str));
+
+  String toRawJson() => json.encode(toJson());
+
+  factory PostgrestResponse.fromJson(Map<String, dynamic> json) =>
+      PostgrestResponse(
+        body: json['body'],
+        status: json['status'],
+        statusText: json['statusText'],
+        error: json['error'] == null
+            ? null
+            : PostgrestError.fromJson(json['error']),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'body': body,
+        'status': status,
+        'statusText': statusText,
+        'error': error == null ? null : error.toJson(),
+      };
+}

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -7,6 +7,6 @@ void main() {
 
   test('basic select table', () async {
     var res = await postgrest.from('users').select().end();
-    expect(res['body'].length, 4);
+    expect(res.body.length, 4);
   });
 }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -12,6 +12,6 @@ void main() {
 
   test('stored procedure', () async {
     var res = await postgrest.rpc('get_status', {'name_param': 'supabot'}).end();
-    expect(res['body'], 'ONLINE');
+    expect(res.body, 'ONLINE');
   });
 }

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -11,7 +11,7 @@ void main() {
         .select()
         .not('status', 'eq', 'OFFLINE')
         .end();
-    expect(res['body'].length, 3);
-    expect(res['body'][1]['username'], 'awailas');
+    expect(res.body.length, 3);
+    expect(res.body[1]['username'], 'awailas');
   });
 }

--- a/test/resource-embedding_test.dart
+++ b/test/resource-embedding_test.dart
@@ -7,7 +7,7 @@ void main() {
 
   test('embedded select', () async {
     var res = await postgrest.from('users').select('messages(*)').end();
-    expect(res['body'][0]['messages'].length, 2);
-    expect(res['body'][1]['messages'].length, 0);
+    expect(res.body[0]['messages'].length, 2);
+    expect(res.body[1]['messages'].length, 0);
   });
 }

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -10,7 +10,7 @@ void main() {
         .from('users')
         .select()
         .order('username', {'ascending': false}).end();
-    expect(res['body'][1]['username'], 'kiwicopple');
-    expect(res['body'][3]['username'], 'awailas');
+    expect(res.body[1]['username'], 'kiwicopple');
+    expect(res.body[3]['username'], 'awailas');
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR to create a feature request in #4 
It has 2 new class in the folder:

- lib/models/postgrest_error.dart
- lib/models/postgrest_response.dart

And change code on lib, example, test to have a response with custom class PostgrestResponse.
Have been move statusCode to PostgrestError.code

## What is the current behavior?

#4 

## What is the new behavior?

![image](https://user-images.githubusercontent.com/20185622/94983521-ab648d80-056d-11eb-8328-6e682f1e67ea.png)

## Additional context

All tests passed on folder test
Not test example/main.dart yet 

![image](https://user-images.githubusercontent.com/20185622/94983499-7b1cef00-056d-11eb-8474-a853619088d5.png)
