### PR TITLE
chore: replace end() with execute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pre-release verion! This repo is still under heavy development and the documenta
 
 The usage should be the same as postgrest-js except:
 
-- You need to call `end()` to finish your query chain.
+- You need to call `execute()` to finish your query chain.
 - `is_` and `in_` filter methods are prefixed with `_` sign to avoid collisions with reserved keywords.
 
 You can find detail documentation from [here](https://supabase.io/docs/about).
@@ -23,7 +23,7 @@ import 'package:postgrest/postgrest.dart';
 
 var url = 'https://example.com/postgrest/endpoint';
 var client = PostgrestClient(url);
-var response = await client.from('users').select().end();
+var response = await client.from('users').select().execute();
 ```
 
 #### Insert records
@@ -37,7 +37,7 @@ var response = await client.from('users')
       .insert([
         { 'username': 'supabot', 'status': 'ONLINE'}
       ])
-      .end();
+      .execute();
 ```
 
 #### Update a record
@@ -50,7 +50,7 @@ var client = PostgrestClient(url);
 var response = await client.from('users')
       .update({ 'status': 'OFFLINE' })
       .eq('username', 'dragarcia')
-      .end();
+      .execute();
 ```
 
 #### Delete records
@@ -63,7 +63,7 @@ var client = PostgrestClient(url);
 var response = await client.from('users')
       .delete()
       .eq('username', 'supabot')
-      .end();
+      .execute();
 ```
 
 ## Contributing

--- a/example/main.dart
+++ b/example/main.dart
@@ -3,14 +3,13 @@ import 'package:postgrest/postgrest.dart';
 /// Example to use with Supabase API https://supabase.io/
 void main(List<String> arguments) async {
   var client = PostgrestClient('SUPABASE_API_ENDPOINT/rest/v1',
-    headers: {
-      'apikey': 'SUPABSE_API_KEY',
-    },
-    schema: 'public'
-  );
+      headers: {
+        'apikey': 'SUPABSE_API_KEY',
+      },
+      schema: 'public');
 
   final response =
-      await client.from('countries').select('*').order('name', ascending: true).end();
+      await client.from('countries').select('*').order('name', ascending: true).execute();
   if (response.status == 200) {
     print('Countries List: ${response.data}.');
   } else {

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -21,7 +21,7 @@ class PostgrestBuilder {
   ///
   /// For more details about switching schemas: https://postgrest.org/en/stable/api.html#switching-schemas
   /// Returns {Future} Resolves when the request has completed.
-  Future<PostgrestResponse> end() async {
+  Future<PostgrestResponse> execute() async {
     try {
       var uppercaseMethod = method.toUpperCase();
       var response;
@@ -147,9 +147,8 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```
   PostgrestBuilder insert(dynamic values, {upsert = false, onConflict}) {
     method = 'POST';
-    headers['Prefer'] = upsert
-        ? 'return=representation,resolution=merge-duplicates'
-        : 'return=representation';
+    headers['Prefer'] =
+        upsert ? 'return=representation,resolution=merge-duplicates' : 'return=representation';
     body = values;
     return this;
   }
@@ -201,7 +200,6 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder {
   /// ```
   PostgrestTransformBuilder order(String column,
       {ascending = false, nullsFirst = false, foreignTable}) {
-
     var key = foreignTable == null ? 'order' : '"${foreignTable}".order';
     var value =
         '"${column}".${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}';

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -10,19 +10,17 @@ void main() {
   });
 
   test('basic select table', () async {
-    var res = await postgrest.from('users').select().end();
+    var res = await postgrest.from('users').select().execute();
     expect(res.data.length, 4);
   });
 
   test('stored procedure', () async {
-    var res = await postgrest.rpc('get_status', {'name_param': 'supabot'}).end();
+    var res = await postgrest.rpc('get_status', {'name_param': 'supabot'}).execute();
     expect(res.data, 'ONLINE');
   });
 
   test('custom headers', () async {
-    var postgrest = PostgrestClient(rootUrl,
-      headers: {'apikey': 'foo'}
-    );
+    var postgrest = PostgrestClient(rootUrl, headers: {'apikey': 'foo'});
     expect(postgrest.from('users').select().headers['apikey'], 'foo');
   });
 
@@ -33,24 +31,24 @@ void main() {
 
   test('switch schema', () async {
     var postgrest = PostgrestClient(rootUrl, schema: 'personal');
-    var res = await postgrest.from('users').select().end();
+    var res = await postgrest.from('users').select().execute();
     expect(res.data.length, 5);
   });
 
   test('on_conflict insert', () async {
     var res = await postgrest.from('users').insert({'username': 'dragarcia', 'status': 'OFFLINE'},
-        upsert: true, onConflict: 'username').end();
+        upsert: true, onConflict: 'username').execute();
     expect(res.data[0]['status'], 'OFFLINE');
   });
 
   test('upsert', () async {
     var res = await postgrest.from('messages').insert(
         {'id': 3, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
-        upsert: true).end();
+        upsert: true).execute();
     //{id: 3, message: foo, username: supabot, channel_id: 2}
     expect(res.data[0]['id'], 3);
 
-    var resMsg = await postgrest.from('messages').select().end();
+    var resMsg = await postgrest.from('messages').select().execute();
     expect(resMsg.data.length, 3);
   });
 
@@ -58,32 +56,32 @@ void main() {
     var res = await postgrest.from('messages').insert([
       {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
       {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1}
-    ]).end();
+    ]).execute();
     expect(res.data.length, 2);
   });
 
   test('basic update', () async {
-    await postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo').end();
+    await postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo').execute();
 
-    var resMsg = await postgrest.from('messages').select().filter('message', 'eq', 'foo').end();
+    var resMsg = await postgrest.from('messages').select().filter('message', 'eq', 'foo').execute();
     resMsg.data.forEach((rec) => expect(rec['channel_id'], 2));
   });
 
   test('basic delete', () async {
-    await postgrest.from('messages').delete().eq('message', 'foo').end();
+    await postgrest.from('messages').delete().eq('message', 'foo').execute();
 
-    var resMsg = await postgrest.from('messages').select().filter('message', 'eq', 'foo').end();
+    var resMsg = await postgrest.from('messages').select().filter('message', 'eq', 'foo').execute();
     expect(resMsg.data.length, 0);
   });
 
   test('missing table', () async {
-    var res = await postgrest.from('missing_table').select().end();
+    var res = await postgrest.from('missing_table').select().execute();
     expect(res.error.code, '404');
   });
 
   test('connection error', () async {
     var postgrest = PostgrestClient('http://this.url.does.not.exist');
-    var res = await postgrest.from('user').select().end();
+    var res = await postgrest.from('user').select().execute();
     expect(res.error.code, 'SocketException');
   });
 }

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -10,22 +10,25 @@ void main() {
   });
 
   test('not', () async {
-    var res = await postgrest.from('users').select().not('status', 'eq', 'OFFLINE').end();
+    var res = await postgrest.from('users').select().not('status', 'eq', 'OFFLINE').execute();
     res.data.forEach((item) {
       expect(item['status'] != ('OFFLINE'), true);
     });
   });
 
   test('or', () async {
-    var res =
-        await postgrest.from('users').select().or('status.eq.OFFLINE,username.eq.supabot').end();
+    var res = await postgrest
+        .from('users')
+        .select()
+        .or('status.eq.OFFLINE,username.eq.supabot')
+        .execute();
     res.data.forEach((item) {
       expect((item['username'] == ('supabot') || item['status'] == ('OFFLINE')), true);
     });
   });
 
   test('eq', () async {
-    var res = await postgrest.from('users').select().eq('username', 'supabot').end();
+    var res = await postgrest.from('users').select().eq('username', 'supabot').execute();
 
     res.data.forEach((item) {
       expect(item['username'] == ('supabot'), true);
@@ -33,49 +36,49 @@ void main() {
   });
 
   test('neq', () async {
-    var res = await postgrest.from('users').select().neq('username', 'supabot').end();
+    var res = await postgrest.from('users').select().neq('username', 'supabot').execute();
     res.data.forEach((item) {
       expect(item['username'] == ('supabot'), false);
     });
   });
 
   test('gt', () async {
-    var res = await postgrest.from('messages').select().gt('id', 1).end();
+    var res = await postgrest.from('messages').select().gt('id', 1).execute();
     res.data.forEach((item) {
       expect(item['id'] > 1, true);
     });
   });
 
   test('gte', () async {
-    var res = await postgrest.from('messages').select().gte('id', 1).end();
+    var res = await postgrest.from('messages').select().gte('id', 1).execute();
     res.data.forEach((item) {
       expect(item['id'] < 1, false);
     });
   });
 
   test('lt', () async {
-    var res = await postgrest.from('messages').select().lt('id', 2).end();
+    var res = await postgrest.from('messages').select().lt('id', 2).execute();
     res.data.forEach((item) {
       expect(item['id'] < 2, true);
     });
   });
 
   test('lte', () async {
-    var res = await postgrest.from('messages').select().lte('id', 2).end();
+    var res = await postgrest.from('messages').select().lte('id', 2).execute();
     res.data.forEach((item) {
       expect(item['id'] > 2, false);
     });
   });
 
   test('like', () async {
-    var res = await postgrest.from('users').select().like('username', '%supa%').end();
+    var res = await postgrest.from('users').select().like('username', '%supa%').execute();
     res.data.forEach((item) {
       expect(item['username'].contains('supa'), true);
     });
   });
 
   test('ilike', () async {
-    var res = await postgrest.from('users').select().ilike('username', '%SUPA%').end();
+    var res = await postgrest.from('users').select().ilike('username', '%SUPA%').execute();
     res.data.forEach((item) {
       var user = item['username'].toLowerCase();
       expect(user.contains('supa'), true);
@@ -83,62 +86,62 @@ void main() {
   });
 
   test('is', () async {
-    var res = await postgrest.from('users').select().is_('data', null).end();
+    var res = await postgrest.from('users').select().is_('data', null).execute();
     res.data.forEach((item) {
       expect(item['data'], null);
     });
   });
 
   test('in', () async {
-    var res = await postgrest.from('users').select().in_('status', ['ONLINE', 'OFFLINE']).end();
+    var res = await postgrest.from('users').select().in_('status', ['ONLINE', 'OFFLINE']).execute();
     res.data.forEach((item) {
       expect(item['status'] == 'ONLINE' || item['status'] == 'OFFLINE', true);
     });
   });
 
   test('cs', () async {
-    var res = await postgrest.from('users').select().cs('age_range', '[1,2)').end();
+    var res = await postgrest.from('users').select().cs('age_range', '[1,2)').execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
   test('cd', () async {
-    var res = await postgrest.from('users').select().cd('age_range', '[1,2)').end();
+    var res = await postgrest.from('users').select().cd('age_range', '[1,2)').execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
   test('sl', () async {
-    var res = await postgrest.from('users').select().sl('age_range', '[2,25)').end();
+    var res = await postgrest.from('users').select().sl('age_range', '[2,25)').execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
   test('sr', () async {
-    var res = await postgrest.from('users').select().sr('age_range', '[2,25)').end();
+    var res = await postgrest.from('users').select().sr('age_range', '[2,25)').execute();
     res.data.forEach((item) {
       expect(item['username'] != 'supabot', true);
     });
   });
 
   test('nxl', () async {
-    var res = await postgrest.from('users').select().nxl('age_range', '[2,25)').end();
+    var res = await postgrest.from('users').select().nxl('age_range', '[2,25)').execute();
     res.data.forEach((item) {
       expect(item['username'] != 'supabot', true);
     });
   });
 
   test('nxr', () async {
-    var res = await postgrest.from('users').select().nxr('age_range', '[2,25)').end();
+    var res = await postgrest.from('users').select().nxr('age_range', '[2,25)').execute();
     res.data.forEach((item) {
       expect(item['username'] == 'supabot', true);
     });
   });
 
   test('adj', () async {
-    var res = await postgrest.from('users').select().adj('age_range', '[2,25)').end();
+    var res = await postgrest.from('users').select().adj('age_range', '[2,25)').execute();
     expect(res.data.length, 3);
   });
 
   test('ov', () async {
-    var res = await postgrest.from('users').select().ov('age_range', '[2,25)').end();
+    var res = await postgrest.from('users').select().ov('age_range', '[2,25)').execute();
     expect(res.data[0]['username'], 'dragarcia');
   });
 
@@ -146,7 +149,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select()
-        .fts('catchphrase', '\'fat\' & \'cat\'', config: 'english').end();
+        .fts('catchphrase', '\'fat\' & \'cat\'', config: 'english')
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
@@ -154,7 +158,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select()
-        .plfts('catchphrase', '\'fat\' & \'cat\'', config: 'english').end();
+        .plfts('catchphrase', '\'fat\' & \'cat\'', config: 'english')
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
@@ -162,7 +167,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select()
-        .phfts('catchphrase', 'cat', config: 'english').end();
+        .phfts('catchphrase', 'cat', config: 'english')
+        .execute();
     expect(res.data.length, 2);
   });
 
@@ -170,7 +176,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select()
-        .wfts('catchphrase', '\'fat\' & \'cat\'', config: 'english').end();
+        .wfts('catchphrase', '\'fat\' & \'cat\'', config: 'english')
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
@@ -183,12 +190,12 @@ void main() {
         .ov('age_range', '[1,2)')
         .eq('status', 'ONLINE')
         .fts('catchphrase', 'cat')
-        .end();
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
   test('filter', () async {
-    var res = await postgrest.from('users').select().filter('username', 'eq', 'supabot').end();
+    var res = await postgrest.from('users').select().filter('username', 'eq', 'supabot').execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
@@ -196,7 +203,7 @@ void main() {
     var res = await postgrest
         .from('users')
         .select()
-        .match({'username': 'supabot', 'status': 'ONLINE'}).end();
+        .match({'username': 'supabot', 'status': 'ONLINE'}).execute();
     expect(res.data[0]['username'], 'supabot');
   });
 }

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -10,14 +10,14 @@ void main() {
   });
 
   test('embedded select', () async {
-    var res = await postgrest.from('users').select('messages(*)').end();
+    var res = await postgrest.from('users').select('messages(*)').execute();
     expect(res.data[0]['messages'].length, 2);
     expect(res.data[1]['messages'].length, 0);
   });
 
   test('embedded eq', () async {
     var res =
-        await postgrest.from('users').select('messages(*)').eq('messages.channel_id', 1).end();
+        await postgrest.from('users').select('messages(*)').eq('messages.channel_id', 1).execute();
     expect(res.data[0]['messages'].length, 1);
     expect(res.data[1]['messages'].length, 0);
     expect(res.data[2]['messages'].length, 0);
@@ -28,7 +28,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select('messages(*)')
-        .order('channel_id', foreignTable: 'messages', ascending: false).end();
+        .order('channel_id', foreignTable: 'messages', ascending: false)
+        .execute();
     expect(res.data[0]['messages'].length, 2);
     expect(res.data[1]['messages'].length, 0);
     expect(res.data[2]['messages'].length, 0);
@@ -39,7 +40,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select('messages(*)')
-        .limit(1, foreignTable: 'messages').end();
+        .limit(1, foreignTable: 'messages')
+        .execute();
     expect(res.data[0]['messages'].length, 1);
     expect(res.data[1]['messages'].length, 0);
     expect(res.data[2]['messages'].length, 0);
@@ -50,7 +52,8 @@ void main() {
     var res = await postgrest
         .from('users')
         .select('messages(*)')
-        .range(1, 1, foreignTable: 'messages').end();
+        .range(1, 1, foreignTable: 'messages')
+        .execute();
     expect(res.data[0]['messages'].length, 1);
     expect(res.data[1]['messages'].length, 0);
     expect(res.data[2]['messages'].length, 0);

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -10,20 +10,20 @@ void main() {
   });
 
   test('order', () async {
-    var res = await postgrest.from('users').select().order('username', ascending: false).end();
+    var res = await postgrest.from('users').select().order('username', ascending: false).execute();
     expect(res.data[1]['username'], 'kiwicopple');
     expect(res.data[3]['username'], 'awailas');
   });
 
   test('limit', () async {
-    var res = await postgrest.from('users').select().limit(1).end();
+    var res = await postgrest.from('users').select().limit(1).execute();
     expect(res.data.length, 1);
   });
 
   test('range', () async {
     var from = 1;
     var to = 3;
-    var res = await postgrest.from('users').select().range(from, to).end();
+    var res = await postgrest.from('users').select().range(from, to).execute();
     //from -1 so that the index is included
     expect(res.data.length, to - (from - 1));
   });
@@ -31,13 +31,13 @@ void main() {
   test('range 1-1', () async {
     var from = 1;
     var to = 1;
-    var res = await postgrest.from('users').select().range(from, to).end();
+    var res = await postgrest.from('users').select().range(from, to).execute();
     //from -1 so that the index is included
     expect(res.data.length, to - (from - 1));
   });
 
   test('single', () async {
-    var res = await postgrest.from('users').select().limit(1).single().end();
+    var res = await postgrest.from('users').select().limit(1).single().execute();
     expect(res.data['username'], 'supabot');
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Replace `end()` with `execute()` to have a consistent syntax so that all the tutorials/examples are reusable for each new language supported. 

#12 
