### PR TITLE
Add head and count option

### DIFF
--- a/lib/postgrest.dart
+++ b/lib/postgrest.dart
@@ -15,7 +15,8 @@ class PostgrestClient {
   /// new PostgrestClient(REST_URL)
   /// new PostgrestClient(REST_URL, headers: { 'apikey': 'foo' })
   /// ```
-  PostgrestClient(this.url, {Map<String, String> headers, this.schema}) : headers = headers ?? {};
+  PostgrestClient(this.url, {Map<String, String> headers, this.schema})
+      : headers = headers ?? {};
 
   /// Authenticates the request with JWT.
   PostgrestClient auth(String token) {
@@ -32,6 +33,14 @@ class PostgrestClient {
   /// Perform a stored procedure call.
   PostgrestBuilder rpc(String fn, Map params) {
     final url = '${this.url}/rpc/$fn';
-    return PostgrestQueryBuilder(url, headers: headers, schema: schema).rpc(params);
+    return PostgrestQueryBuilder(url, headers: headers, schema: schema)
+        .rpc(params);
   }
+}
+
+/// Returns count as part of the response when specified.
+enum CountOption {
+  exact,
+  planned,
+  estimated,
 }

--- a/lib/postgrest.dart
+++ b/lib/postgrest.dart
@@ -37,10 +37,3 @@ class PostgrestClient {
         .rpc(params);
   }
 }
-
-/// Returns count as part of the response when specified.
-enum CountOption {
-  exact,
-  planned,
-  estimated,
-}

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -212,12 +212,9 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.rpc('get_status', { name_param: 'supabot' })
   /// ```
-  PostgrestBuilder rpc(dynamic params, {bool head = false}) {
+  PostgrestBuilder rpc(dynamic params) {
     method = 'POST';
     body = params;
-    if (head) {
-      method = 'HEAD';
-    }
     return this;
   }
 }

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -103,9 +103,11 @@ class PostgrestBuilder {
       }
 
       final contentRange = response.headers['content-range'];
-      count = contentRange.split('/')[1] == '*'
-          ? null
-          : int.parse(contentRange.split('/')[1]);
+      if (contentRange != null) {
+        count = contentRange.split('/').last == '*'
+            ? null
+            : int.parse(contentRange.split('/').last);
+      }
 
       return PostgrestResponse(
         data: body,

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -4,6 +4,7 @@ import 'dart:core';
 
 import 'package:http/http.dart' as http;
 
+import '../postgrest.dart';
 import 'postgrest_error.dart';
 import 'postgrest_response.dart';
 
@@ -78,10 +79,12 @@ class PostgrestBuilder {
     } else {
       dynamic body;
       int count;
-      try {
-        body = json.decode(response.body);
-      } on FormatException catch (_) {
-        body = response.body;
+      if (response.request.method != 'HEAD') {
+        try {
+          body = json.decode(response.body);
+        } on FormatException catch (_) {
+          body = response.body;
+        }
       }
 
       final contentRange = response.headers['content-range'];
@@ -176,7 +179,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
         : 'return=representation';
     body = values;
     if (count != null) {
-      headers['Prefer'] += 'count=${count.toString().split('.')[1]}';
+      headers['Prefer'] += ',count=${count.toString().split('.')[1]}';
     }
     return this;
   }
@@ -191,7 +194,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     headers['Prefer'] = 'return=representation';
     body = values;
     if (count != null) {
-      headers['Prefer'] += 'count=${count.toString().split('.')[1]}';
+      headers['Prefer'] += ',count=${count.toString().split('.')[1]}';
     }
     return PostgrestFilterBuilder(this);
   }
@@ -205,7 +208,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     method = 'DELETE';
     headers['Prefer'] = 'return=representation';
     if (count != null) {
-      headers['Prefer'] += 'count=${count.toString().split('.')[1]}';
+      headers['Prefer'] += ',count=${count.toString().split('.')[1]}';
     }
     return PostgrestFilterBuilder(this);
   }
@@ -606,11 +609,4 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     query.forEach((k, v) => appendSearchParams('$k', 'eq.$v'));
     return this;
   }
-}
-
-/// Three options for count parameter
-enum CountOption {
-  exact,
-  planned,
-  estimated,
 }

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -4,7 +4,7 @@ import 'dart:core';
 
 import 'package:http/http.dart' as http;
 
-import '../postgrest.dart';
+import 'count_option.dart';
 import 'postgrest_error.dart';
 import 'postgrest_response.dart';
 
@@ -150,7 +150,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     }).join('');
 
     if (count != null) {
-      headers['Prefer'] = 'count=${count.toString().split('.')[1]}';
+      headers['Prefer'] = 'count=${count.name()}';
     }
     if (head) {
       method = 'HEAD';
@@ -179,7 +179,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
         : 'return=representation';
     body = values;
     if (count != null) {
-      headers['Prefer'] += ',count=${count.toString().split('.')[1]}';
+      headers['Prefer'] += ',count=${count.name()}';
     }
     return this;
   }
@@ -194,7 +194,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     headers['Prefer'] = 'return=representation';
     body = values;
     if (count != null) {
-      headers['Prefer'] += ',count=${count.toString().split('.')[1]}';
+      headers['Prefer'] += ',count=${count.name()}';
     }
     return PostgrestFilterBuilder(this);
   }
@@ -208,7 +208,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     method = 'DELETE';
     headers['Prefer'] = 'return=representation';
     if (count != null) {
-      headers['Prefer'] += ',count=${count.toString().split('.')[1]}';
+      headers['Prefer'] += ',count=${count.name()}';
     }
     return PostgrestFilterBuilder(this);
   }
@@ -226,7 +226,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     method = 'POST';
     body = params;
     if (count != null) {
-      headers['Prefer'] = 'count=${count.toString().split('.')[1]}';
+      headers['Prefer'] = 'count=${count.name()}';
     }
     if (head) {
       method = 'HEAD';

--- a/lib/src/count_option.dart
+++ b/lib/src/count_option.dart
@@ -1,0 +1,12 @@
+/// Returns count as part of the response when specified.
+enum CountOption {
+  exact,
+  planned,
+  estimated,
+}
+
+extension CountOptionName on CountOption {
+  String name() {
+    return toString().split('.').last;
+  }
+}

--- a/lib/src/postgrest_response.dart
+++ b/lib/src/postgrest_response.dart
@@ -12,20 +12,24 @@ class PostgrestResponse {
     this.status,
     this.statusText,
     this.error,
+    this.count,
   });
 
   final dynamic data;
   final int status;
   final String statusText;
   final PostgrestError error;
+  final int count;
 
-  factory PostgrestResponse.fromJson(Map<String, dynamic> json) => PostgrestResponse(
+  factory PostgrestResponse.fromJson(Map<String, dynamic> json) =>
+      PostgrestResponse(
         data: json['body'],
         status: json['status'] as int,
         statusText: json['statusText'] as String,
         error: json['error'] == null
             ? null
             : PostgrestError.fromJson(json['error'] as Map<String, dynamic>),
+        count: json['count'] as int,
       );
 
   Map<String, dynamic> toJson() => {
@@ -33,5 +37,6 @@ class PostgrestResponse {
         'status': status,
         'statusText': statusText,
         'error': error?.toJson(),
+        'count': count,
       };
 }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -133,7 +133,7 @@ void main() {
 
   test('stored procedure with head: true', () async {
     final res =
-        await postgrest.from('users').rpc('get_status', head: true).execute();
+        await postgrest.from('users').rpc('get_status').execute(head: true);
     expect(res.data, null);
   });
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -164,9 +164,10 @@ void main() {
   });
 
   test('delete with count: exact', () async {
+    final resd = await postgrest.from('users').select().execute();
     final res = await postgrest
         .from('users')
-        .delete()
+        .delete(count: CountOption.exact)
         .eq('username', 'countexact')
         .execute();
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -102,15 +102,15 @@ void main() {
   });
 
   test('select with head:true', () async {
-    final res = await postgrest.from('users').select(head: true).execute();
+    final res = await postgrest.from('users').select().execute(head: true);
     expect(res.data, null);
   });
 
   test('select with head:true, count: exact', () async {
     final res = await postgrest
         .from('users')
-        .select(head: true, count: CountOption.exact)
-        .execute();
+        .select()
+        .execute(head: true, count: CountOption.exact);
     expect(res.data, null);
     expect(res.count, 4);
   });
@@ -118,16 +118,16 @@ void main() {
   test('select with  count: planned', () async {
     final res = await postgrest
         .from('users')
-        .select(count: CountOption.exact)
-        .execute();
+        .select()
+        .execute(count: CountOption.exact);
     expect(res.count, const TypeMatcher<int>());
   });
 
   test('select with head:true, count: estimated', () async {
     final res = await postgrest
         .from('users')
-        .select(count: CountOption.exact)
-        .execute();
+        .select()
+        .execute(count: CountOption.exact);
     expect(res.count, const TypeMatcher<int>());
   });
 
@@ -140,36 +140,33 @@ void main() {
   test('stored procedure with count: exact', () async {
     final res = await postgrest
         .from('users')
-        .rpc('get_status', count: CountOption.exact)
-        .execute();
+        .rpc('get_status')
+        .execute(count: CountOption.exact);
     expect(res.count, const TypeMatcher<int>());
   });
 
   test('insert with count: exact', () async {
     final res = await postgrest.from('users').insert(
-      {'username': 'countexact', 'status': 'OFFLINE'},
-      upsert: true,
-      onConflict: 'username',
-      count: CountOption.exact,
-    ).execute();
+        {'username': 'countexact', 'status': 'OFFLINE'},
+        upsert: true, onConflict: 'username').execute(count: CountOption.exact);
     expect(res.count, 1);
   });
 
   test('update with count: exact', () async {
     final res = await postgrest
         .from('users')
-        .update({'status': 'ONLINE'}, count: CountOption.exact)
+        .update({'status': 'ONLINE'})
         .eq('username', 'countexact')
-        .execute();
+        .execute(count: CountOption.exact);
     expect(res.count, 1);
   });
 
   test('delete with count: exact', () async {
     final res = await postgrest
         .from('users')
-        .delete(count: CountOption.exact)
+        .delete()
         .eq('username', 'countexact')
-        .execute();
+        .execute(count: CountOption.exact);
 
     expect(res.count, 1);
   });

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -15,7 +15,8 @@ void main() {
   });
 
   test('stored procedure', () async {
-    final res = await postgrest.rpc('get_status', {'name_param': 'supabot'}).execute();
+    final res =
+        await postgrest.rpc('get_status', {'name_param': 'supabot'}).execute();
     expect(res.data, 'ONLINE');
   });
 
@@ -26,7 +27,8 @@ void main() {
 
   test('auth', () async {
     postgrest = PostgrestClient(rootUrl).auth('foo');
-    expect(postgrest.from('users').select().headers['Authorization'], 'Bearer foo');
+    expect(postgrest.from('users').select().headers['Authorization'],
+        'Bearer foo');
   });
 
   test('switch schema', () async {
@@ -36,7 +38,8 @@ void main() {
   });
 
   test('on_conflict insert', () async {
-    final res = await postgrest.from('users').insert({'username': 'dragarcia', 'status': 'OFFLINE'},
+    final res = await postgrest.from('users').insert(
+        {'username': 'dragarcia', 'status': 'OFFLINE'},
         upsert: true, onConflict: 'username').execute();
     expect(res.data[0]['status'], 'OFFLINE');
   });
@@ -61,18 +64,28 @@ void main() {
   });
 
   test('basic update', () async {
-    await postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo').execute();
+    await postgrest
+        .from('messages')
+        .update({'channel_id': 2})
+        .eq('message', 'foo')
+        .execute();
 
-    final resMsg =
-        await postgrest.from('messages').select().filter('message', 'eq', 'foo').execute();
+    final resMsg = await postgrest
+        .from('messages')
+        .select()
+        .filter('message', 'eq', 'foo')
+        .execute();
     resMsg.data.forEach((rec) => expect(rec['channel_id'], 2));
   });
 
   test('basic delete', () async {
     await postgrest.from('messages').delete().eq('message', 'foo').execute();
 
-    final resMsg =
-        await postgrest.from('messages').select().filter('message', 'eq', 'foo').execute();
+    final resMsg = await postgrest
+        .from('messages')
+        .select()
+        .filter('message', 'eq', 'foo')
+        .execute();
     expect(resMsg.data.length, 0);
   });
 
@@ -85,5 +98,78 @@ void main() {
     final postgrest = PostgrestClient('http://this.url.does.not.exist');
     final res = await postgrest.from('user').select().execute();
     expect(res.error.code, 'SocketException');
+  });
+
+  test('select with head:true', () async {
+    final res = await postgrest.from('users').select(head: true).execute();
+    expect(res.data, null);
+  });
+
+  test('select with head:true, count: exact', () async {
+    final res = await postgrest
+        .from('users')
+        .select(head: true, count: CountOption.exact)
+        .execute();
+    expect(res.data, null);
+    expect(res.count, 4);
+  });
+
+  test('select with  count: planned', () async {
+    final res = await postgrest
+        .from('users')
+        .select(count: CountOption.exact)
+        .execute();
+    expect(res.count, const TypeMatcher<int>());
+  });
+
+  test('select with head:true, count: estimated', () async {
+    final res = await postgrest
+        .from('users')
+        .select(count: CountOption.exact)
+        .execute();
+    expect(res.count, const TypeMatcher<int>());
+  });
+
+  test('stored procedure with head: true', () async {
+    final res =
+        await postgrest.from('users').rpc('get_status', head: true).execute();
+    expect(res.data, null);
+  });
+
+  test('stored procedure with count: exact', () async {
+    final res = await postgrest
+        .from('users')
+        .rpc('get_status', count: CountOption.exact)
+        .execute();
+    expect(res.count, const TypeMatcher<int>());
+  });
+
+  test('insert with count: exact', () async {
+    final res = await postgrest.from('users').insert(
+      {'username': 'countexact', 'status': 'OFFLINE'},
+      upsert: true,
+      onConflict: 'username',
+      count: CountOption.exact,
+    ).execute();
+    expect(res.count, 1);
+  });
+
+  test('update with count: exact', () async {
+    final res = await postgrest
+        .from('users')
+        .update({'status': 'OFFLINE'}, count: CountOption.exact)
+        .eq('username', 'supabot')
+        .execute();
+    expect(res.count, 1);
+  });
+
+  test('delete with count: exact', () async {
+    final res = await postgrest
+        .from('users')
+        .delete()
+        .eq('username', 'supabot')
+        .execute();
+
+    expect(res.count, 1);
   });
 }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -157,8 +157,8 @@ void main() {
   test('update with count: exact', () async {
     final res = await postgrest
         .from('users')
-        .update({'status': 'OFFLINE'}, count: CountOption.exact)
-        .eq('username', 'supabot')
+        .update({'status': 'ONLINE'}, count: CountOption.exact)
+        .eq('username', 'countexact')
         .execute();
     expect(res.count, 1);
   });
@@ -167,7 +167,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .delete()
-        .eq('username', 'supabot')
+        .eq('username', 'countexact')
         .execute();
 
     expect(res.count, 1);

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,3 +1,4 @@
+import 'package:postgrest/src/count_option.dart';
 import 'package:test/test.dart';
 import 'package:postgrest/postgrest.dart';
 
@@ -164,7 +165,6 @@ void main() {
   });
 
   test('delete with count: exact', () async {
-    final resd = await postgrest.from('users').select().execute();
     final res = await postgrest
         .from('users')
         .delete(count: CountOption.exact)

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -10,8 +10,7 @@ void main() {
   });
 
   test('embedded select', () async {
-    final res =
-        await postgrest.from('users').select(columns: 'messages(*)').execute();
+    final res = await postgrest.from('users').select('messages(*)').execute();
     expect(res.data[0]['messages'].length, 2);
     expect(res.data[1]['messages'].length, 0);
   });
@@ -19,7 +18,7 @@ void main() {
   test('embedded eq', () async {
     final res = await postgrest
         .from('users')
-        .select(columns: 'messages(*)')
+        .select('messages(*)')
         .eq('messages.channel_id', 1)
         .execute();
     expect(res.data[0]['messages'].length, 1);
@@ -31,7 +30,7 @@ void main() {
   test('embedded order', () async {
     final res = await postgrest
         .from('users')
-        .select(columns: 'messages(*)')
+        .select('messages(*)')
         .order('channel_id', foreignTable: 'messages')
         .execute();
     expect(res.data[0]['messages'].length, 2);
@@ -43,7 +42,7 @@ void main() {
   test('embedded limit', () async {
     final res = await postgrest
         .from('users')
-        .select(columns: 'messages(*)')
+        .select('messages(*)')
         .limit(1, foreignTable: 'messages')
         .execute();
     expect(res.data[0]['messages'].length, 1);
@@ -55,7 +54,7 @@ void main() {
   test('embedded range', () async {
     final res = await postgrest
         .from('users')
-        .select(columns: 'messages(*)')
+        .select('messages(*)')
         .range(1, 1, foreignTable: 'messages')
         .execute();
     expect(res.data[0]['messages'].length, 1);

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -10,14 +10,18 @@ void main() {
   });
 
   test('embedded select', () async {
-    final res = await postgrest.from('users').select('messages(*)').execute();
+    final res =
+        await postgrest.from('users').select(columns: 'messages(*)').execute();
     expect(res.data[0]['messages'].length, 2);
     expect(res.data[1]['messages'].length, 0);
   });
 
   test('embedded eq', () async {
-    final res =
-        await postgrest.from('users').select('messages(*)').eq('messages.channel_id', 1).execute();
+    final res = await postgrest
+        .from('users')
+        .select(columns: 'messages(*)')
+        .eq('messages.channel_id', 1)
+        .execute();
     expect(res.data[0]['messages'].length, 1);
     expect(res.data[1]['messages'].length, 0);
     expect(res.data[2]['messages'].length, 0);
@@ -27,7 +31,7 @@ void main() {
   test('embedded order', () async {
     final res = await postgrest
         .from('users')
-        .select('messages(*)')
+        .select(columns: 'messages(*)')
         .order('channel_id', foreignTable: 'messages')
         .execute();
     expect(res.data[0]['messages'].length, 2);
@@ -39,7 +43,7 @@ void main() {
   test('embedded limit', () async {
     final res = await postgrest
         .from('users')
-        .select('messages(*)')
+        .select(columns: 'messages(*)')
         .limit(1, foreignTable: 'messages')
         .execute();
     expect(res.data[0]['messages'].length, 1);
@@ -51,7 +55,7 @@ void main() {
   test('embedded range', () async {
     final res = await postgrest
         .from('users')
-        .select('messages(*)')
+        .select(columns: 'messages(*)')
         .range(1, 1, foreignTable: 'messages')
         .execute();
     expect(res.data[0]['messages'].length, 1);


### PR DESCRIPTION
## What kind of change does this PR introduce?

This feature is postgrest-dart equivalent of this feature in postgrest-js
https://github.com/supabase/postgrest-js/pull/147

## What is the current behavior?

There are not head or count options

## What is the new behavior?

head and count options are added
