### PR TITLE
Update postgrest.dart

### DIFF
--- a/lib/postgrest.dart
+++ b/lib/postgrest.dart
@@ -1,2 +1,4 @@
+library postgrest;
 export 'src/builder.dart';
 export 'src/postgrest.dart';
+export 'src/postgrest_error.dart';


### PR DESCRIPTION
Expose PostgrestError so we can use it on a try catch block
```dart
import 'package:postgrest/postgrest.dart' show PostgrestError;
try {
      var response =
          await client.from('features').insert(feature.toMap()).execute();
      if (response.error != null) {
      // at the moment we can only fetch the error on this code 
        print( "ERROR ${response.error.code}", "${response.error.message}");
      }
    } on PostgrestError {
      // even after exposing this is not trigger
    } catch (e, s) {
     // error and stackstrace cannot be catch ?
      print("${s.toString()}");
    }
```