### PR TITLE
Make UPSERT its own function

### DIFF
--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -49,20 +49,38 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
 
   /// Performs an INSERT into the table.
   ///
-  /// When [options] has `upsert` is true, performs an UPSERT.
   /// ```dart
-  /// postgrest.from('messages').insert({ message: 'foo', username: 'supabot', channel_id: 1 })
-  /// postgrest.from('messages').insert({ id: 3, message: 'foo', username: 'supabot', channel_id: 2 }, { upsert: true })
+  /// postgrest.from('messages').insert({ 'message': 'foo', 'username': 'supabot', 'channel_id': 1 })
   /// ```
   PostgrestBuilder insert(
     dynamic values, {
-    bool upsert = false,
+    @Deprecated('Use `upsert()` method instead') bool upsert = false,
+    @Deprecated('Use `upsert()` method instead') String? onConflict,
+  }) {
+    method = 'POST';
+    headers['Prefer'] =
+        upsert ? 'return=representation,resolution=merge-duplicates' : 'return=representation';
+    if (onConflict != null) {
+      url.queryParameters.addAll({'on_conflict': onConflict});
+    }
+    body = values;
+    return this;
+  }
+
+  /// Performs an UPSERT into the table.
+  ///
+  /// ```dart
+  /// postgrest.from('messages').upsert({ 'id': 3, message: 'foo', 'username': 'supabot', 'channel_id': 2 }, { upsert: true })
+  /// ```
+  PostgrestBuilder upsert(
+    dynamic values, {
     String? onConflict,
   }) {
     method = 'POST';
-    headers['Prefer'] = upsert
-        ? 'return=representation,resolution=merge-duplicates'
-        : 'return=representation';
+    headers['Prefer'] = 'return=representation,resolution=merge-duplicates';
+    if (onConflict != null) {
+      url.queryParameters.addAll({'on_conflict': onConflict});
+    }
     body = values;
     return this;
   }
@@ -70,7 +88,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// Performs an UPDATE on the table.
   ///
   /// ```dart
-  /// postgrest.from('messages').update({ channel_id: 2 }).eq('message', 'foo')
+  /// postgrest.from('messages').update({ 'channel_id': 2 }).eq('message', 'foo')
   /// ```
   PostgrestFilterBuilder update(Map values) {
     method = 'PATCH';

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -61,7 +61,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     headers['Prefer'] =
         upsert ? 'return=representation,resolution=merge-duplicates' : 'return=representation';
     if (onConflict != null) {
-      url.queryParameters.addAll({'on_conflict': onConflict});
+      url = url.replace(queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
     }
     body = values;
     return this;
@@ -79,7 +79,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     method = 'POST';
     headers['Prefer'] = 'return=representation,resolution=merge-duplicates';
     if (onConflict != null) {
-      url.queryParameters.addAll({'on_conflict': onConflict});
+      url = url.replace(queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
     }
     body = values;
     return this;

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -49,17 +49,17 @@ void main() {
     expect(res.data.length, 5);
   });
 
-  test('on_conflict insert', () async {
-    final res = await postgrest.from('users').insert({'username': 'dragarcia', 'status': 'OFFLINE'},
-        upsert: true, onConflict: 'username').execute();
+  test('on_conflict upsert', () async {
+    final res = await postgrest
+        .from('users')
+        .upsert({'username': 'dragarcia', 'status': 'OFFLINE'}, onConflict: 'username').execute();
     expect(res.data[0]['status'], 'OFFLINE');
   });
 
   test('upsert', () async {
-    final res = await postgrest.from('messages').insert(
-        {'id': 3, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
-        upsert: true).execute();
-    //{id: 3, message: foo, username: supabot, channel_id: 2}
+    final res = await postgrest
+        .from('messages')
+        .upsert({'id': 3, 'message': 'foo', 'username': 'supabot', 'channel_id': 2}).execute();
     expect(res.data[0]['id'], 3);
 
     final resMsg = await postgrest.from('messages').select().execute();
@@ -137,9 +137,9 @@ void main() {
   });
 
   test('insert with count: exact', () async {
-    final res = await postgrest.from('users').insert(
+    final res = await postgrest.from('users').upsert(
         {'username': 'countexact', 'status': 'OFFLINE'},
-        upsert: true, onConflict: 'username').execute(count: CountOption.exact);
+        onConflict: 'username').execute(count: CountOption.exact);
     expect(res.count, 1);
   });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduced an `upsert()` method for upserting instead of doing it with `insert(upsert: true)`. 
This PR aligns postgrest-dart with postgrest-js about [this PR](https://github.com/supabase/postgrest-js/pull/167).

## What is the current behavior?

Upsert is done with `insert()` method. 

## What is the new behavior?

There is a new separate `upsert()` method just for upserting. 
