### PR TITLE
feat: Add CSV response

### DIFF
--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -85,7 +85,7 @@ abstract class PostgrestBuilder {
         response = await client.head(url, headers: headers);
       }
 
-      return parseJsonResponse(response);
+      return parseResponse(response);
     } catch (e) {
       final error = PostgrestError(code: e.runtimeType.toString(), message: e.toString());
       return PostgrestResponse(
@@ -96,16 +96,20 @@ abstract class PostgrestBuilder {
   }
 
   /// Parse request response to json object if possible
-  PostgrestResponse parseJsonResponse(http.Response response) {
+  PostgrestResponse parseResponse(http.Response response) {
     if (response.statusCode >= 200 && response.statusCode <= 299) {
       dynamic body;
       int? count;
 
       if (response.request!.method != 'HEAD') {
-        try {
-          body = json.decode(response.body);
-        } on FormatException catch (_) {
-          body = null;
+        if (response.request!.headers['Accept'] == 'text/csv') {
+          body = response.body;
+        } else {
+          try {
+            body = json.decode(response.body);
+          } on FormatException catch (_) {
+            body = null;
+          }
         }
       }
 

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -92,4 +92,15 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder {
     headers['Accept'] = 'application/vnd.pgrst.object+json';
     return this;
   }
+
+  /// Retrieves the response as CSV.
+  /// This will skip object parsing.
+  ///
+  /// ```dart
+  /// postgrest.from('users').select().csv()
+  /// ```
+  PostgrestTransformBuilder csv() {
+    headers['Accept'] = 'text/csv';
+    return this;
+  }
 }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -123,6 +123,11 @@ void main() {
     expect(res.count, const TypeMatcher<int>());
   });
 
+  test('select with csv', () async {
+    final res = await postgrest.from('users').select().csv().execute();
+    expect(res.data, const TypeMatcher<String>());
+  });
+
   test('stored procedure with head: true', () async {
     final res = await postgrest.rpc('get_status').execute(head: true);
     expect(res.error, isNotNull);


### PR DESCRIPTION
Add CSV response support as mentioned in https://github.com/supabase/postgrest-js/issues/186 and https://github.com/supabase/postgrest-js/pull/187.

This simple returns the unparsed 'text/csv' response from PostgREST