### PR TITLE
Added count_option export

### DIFF
--- a/lib/postgrest.dart
+++ b/lib/postgrest.dart
@@ -1,3 +1,4 @@
+export 'src/count_option.dart';
 export 'src/postgrest.dart';
 export 'src/postgrest_builder.dart';
 export 'src/postgrest_error.dart';
@@ -6,3 +7,4 @@ export 'src/postgrest_query_builder.dart';
 export 'src/postgrest_response.dart';
 export 'src/postgrest_rpc_builder.dart';
 export 'src/postgrest_transform_builder.dart';
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added a missing export to be able to use the CountOption in queries.

## What is the current behavior?

Cannot use the CountOption enum because it is not exported by the package.

## What is the new behavior?


## Additional context

