### PR TITLE
Support sorting by multiple columns

### DIFF
--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -45,7 +45,8 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder {
   PostgrestTransformBuilder order(String column,
       {bool ascending = false, bool nullsFirst = false, String? foreignTable}) {
     final key = foreignTable == null ? 'order' : '"$foreignTable".order';
-    final value =
+    final existingOrder = url.queryParameters[key];
+    final value = '${existingOrder == null ? '' : '$existingOrder,'}'
         '"$column".${ascending ? 'asc' : 'desc'}.${nullsFirst ? 'nullsfirst' : 'nullslast'}';
 
     appendSearchParams(key, value);

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -35,8 +35,21 @@ void main() {
         .execute();
     expect(res.data[0]['messages'].length, 2);
     expect(res.data[1]['messages'].length, 0);
-    expect(res.data[2]['messages'].length, 0);
-    expect(res.data[3]['messages'].length, 0);
+    expect(res.data[0]['messages'][0]['id'], 2);
+  });
+
+  test('embedded order on multiple columns', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username, messages(*)')
+        .order('username', ascending: true)
+        .order('channel_id', foreignTable: 'messages')
+        .execute();
+    expect(res.data[0]['username'], 'awailas');
+    expect(res.data[3]['username'], 'supabot');
+    expect(res.data[0]['messages'].length, 0);
+    expect(res.data[3]['messages'].length, 2);
+    expect(res.data[3]['messages'][0]['id'], 2);
   });
 
   test('embedded limit', () async {

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -15,6 +15,13 @@ void main() {
     expect(res.data[3]['username'], 'awailas');
   });
 
+  test('order on multiple columns', () async {
+    final res = await postgrest.from('users').select().order('status', ascending: true).order('username').execute();
+    expect(res.data[0]['username'], 'supabot');
+    expect(res.data[2]['username'], 'kiwicopple');
+    expect(res.data[3]['username'], 'dragarcia');
+  });
+
   test('limit', () async {
     final res = await postgrest.from('users').select().limit(1).execute();
     expect(res.data.length, 1);

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -16,9 +16,9 @@ void main() {
   });
 
   test('order on multiple columns', () async {
-    final res = await postgrest.from('users').select().order('status', ascending: true).order('username').execute();
-    expect(res.data[0]['username'], 'supabot');
-    expect(res.data[2]['username'], 'kiwicopple');
+    final res = await postgrest.from('users').select().order('catchphrase', ascending: true).order('username').execute();
+    expect(res.data[0]['username'], 'kiwicopple');
+    expect(res.data[2]['username'], 'supabot');
     expect(res.data[3]['username'], 'dragarcia');
   });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Align the functionality of `order()` with that of postgres-js by adding the same [new feature](https://github.com/supabase/postgrest-js/pull/162).
This closes #30 .

## What is the current behavior?

Sorting by multiple columns is not supported.

## What is the new behavior?

Multiple `order()`s can be used together to sort records by multiple columns. See #30 for details.

## Additional context

It looks like transforms_test.dart does not follow the `lines_longer_than_80_chars` linter rule, so I didn't run `dart format` on the file.

---

I fixed one of the existing tests too.

https://github.com/supabase/postgrest-dart/blob/c8a19085c0341702a7607ec10f166e51ef52b97d/test/resource_embedding_test.dart#L30-L40

This is the test code before my fix. It only checked the number of results without checking the order, which was not appropriate as a test for sorting.

---

I ignored the equivalent tests in postgres-js because they don't make sure that sort results are as expected.

https://github.com/supabase/postgrest-js/blob/e5f5dfae7da22f4ff63c11c124d65d0699b7b890/test/transforms.ts#L10-L17
https://github.com/supabase/postgrest-js/blob/e5f5dfae7da22f4ff63c11c124d65d0699b7b890/test/resource-embedding.ts#L41-L48

The `messages` table has two records with the same username ("supabot"), so sorting by the column does not mean the expected behaviour is correctly tested. I think these should be fixed.
