### PR TITLE
Enforcinng letters per line and lint in Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install dependencies
         run: pub get
 
+      - name: dartfmt
+        run: dart format lib test -l 80 --set-exit-if-changed
+
+      - name: analyzer
+        run: dart analyze --fatal-warnings --fatal-infos .
+
       - name: Build Docker image
         run: |
           cd infra/db

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:lint/analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false 

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,11 +5,14 @@ import 'package:postgrest/src/count_option.dart';
 dynamic main() async {
   const supabaseUrl = '';
   const supabaseKey = '';
-  final client =
-      PostgrestClient('$supabaseUrl/rest/v1', headers: {'apikey': supabaseKey}, schema: 'public');
+  final client = PostgrestClient('$supabaseUrl/rest/v1',
+      headers: {'apikey': supabaseKey}, schema: 'public');
 
   try {
-    final response = await client.from('countries').select().execute(count: CountOption.exact);
+    final response = await client
+        .from('countries')
+        .select()
+        .execute(count: CountOption.exact);
     if (response.error != null) {
       throw response.error!;
     }

--- a/lib/postgrest.dart
+++ b/lib/postgrest.dart
@@ -7,4 +7,3 @@ export 'src/postgrest_query_builder.dart';
 export 'src/postgrest_response.dart';
 export 'src/postgrest_rpc_builder.dart';
 export 'src/postgrest_transform_builder.dart';
-

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -87,7 +87,8 @@ abstract class PostgrestBuilder {
 
       return parseResponse(response);
     } catch (e) {
-      final error = PostgrestError(code: e.runtimeType.toString(), message: e.toString());
+      final error =
+          PostgrestError(code: e.runtimeType.toString(), message: e.toString());
       return PostgrestResponse(
         status: 500,
         error: error,
@@ -115,8 +116,9 @@ abstract class PostgrestBuilder {
 
       final contentRange = response.headers['content-range'];
       if (contentRange != null) {
-        count =
-            contentRange.split('/').last == '*' ? null : int.parse(contentRange.split('/').last);
+        count = contentRange.split('/').last == '*'
+            ? null
+            : int.parse(contentRange.split('/').last);
       }
 
       return PostgrestResponse(
@@ -128,7 +130,8 @@ abstract class PostgrestBuilder {
       PostgrestError error;
       if (response.request!.method != 'HEAD') {
         try {
-          final Map<String, dynamic> errorJson = json.decode(response.body) as Map<String, dynamic>;
+          final Map<String, dynamic> errorJson =
+              json.decode(response.body) as Map<String, dynamic>;
           error = PostgrestError.fromJson(errorJson);
         } catch (_) {
           error = PostgrestError(message: response.body);

--- a/lib/src/postgrest_error.dart
+++ b/lib/src/postgrest_error.dart
@@ -8,13 +8,13 @@ class PostgrestError {
   });
 
   String message;
-  dynamic? details;
+  dynamic details;
   String? hint;
   String? code;
 
   factory PostgrestError.fromJson(Map<String, dynamic> json) => PostgrestError(
         message: json['message'] as String,
-        details: json['details'] as dynamic?,
+        details: json['details'] as dynamic,
         hint: json['hint'] as String?,
         code: json['code'] as String?,
       );

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -58,10 +58,12 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     @Deprecated('Use `upsert()` method instead') String? onConflict,
   }) {
     method = 'POST';
-    headers['Prefer'] =
-        upsert ? 'return=representation,resolution=merge-duplicates' : 'return=representation';
+    headers['Prefer'] = upsert
+        ? 'return=representation,resolution=merge-duplicates'
+        : 'return=representation';
     if (onConflict != null) {
-      url = url.replace(queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
+      url = url.replace(
+          queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
     }
     body = values;
     return this;
@@ -79,7 +81,8 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     method = 'POST';
     headers['Prefer'] = 'return=representation,resolution=merge-duplicates';
     if (onConflict != null) {
-      url = url.replace(queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
+      url = url.replace(
+          queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
     }
     body = values;
     return this;

--- a/lib/src/postgrest_response.dart
+++ b/lib/src/postgrest_response.dart
@@ -14,7 +14,8 @@ class PostgrestResponse {
   final PostgrestError? error;
   final int? count;
 
-  factory PostgrestResponse.fromJson(Map<String, dynamic> json) => PostgrestResponse(
+  factory PostgrestResponse.fromJson(Map<String, dynamic> json) =>
+      PostgrestResponse(
         data: json['body'],
         status: json['status'] as int?,
         error: json['error'] == null

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -16,7 +16,8 @@ void main() {
   });
 
   test('stored procedure', () async {
-    final res = await postgrest.rpc('get_status', params: {'name_param': 'supabot'}).execute();
+    final res = await postgrest
+        .rpc('get_status', params: {'name_param': 'supabot'}).execute();
     expect(res.data, 'ONLINE');
   });
 
@@ -40,7 +41,8 @@ void main() {
 
   test('auth', () async {
     postgrest = PostgrestClient(rootUrl).auth('foo');
-    expect(postgrest.from('users').select().headers['Authorization'], 'Bearer foo');
+    expect(postgrest.from('users').select().headers['Authorization'],
+        'Bearer foo');
   });
 
   test('switch schema', () async {
@@ -50,16 +52,19 @@ void main() {
   });
 
   test('on_conflict upsert', () async {
-    final res = await postgrest
-        .from('users')
-        .upsert({'username': 'dragarcia', 'status': 'OFFLINE'}, onConflict: 'username').execute();
+    final res = await postgrest.from('users').upsert(
+        {'username': 'dragarcia', 'status': 'OFFLINE'},
+        onConflict: 'username').execute();
     expect(res.data[0]['status'], 'OFFLINE');
   });
 
   test('upsert', () async {
-    final res = await postgrest
-        .from('messages')
-        .upsert({'id': 3, 'message': 'foo', 'username': 'supabot', 'channel_id': 2}).execute();
+    final res = await postgrest.from('messages').upsert({
+      'id': 3,
+      'message': 'foo',
+      'username': 'supabot',
+      'channel_id': 2
+    }).execute();
     expect(res.data[0]['id'], 3);
 
     final resMsg = await postgrest.from('messages').select().execute();
@@ -75,18 +80,28 @@ void main() {
   });
 
   test('basic update', () async {
-    await postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo').execute();
+    await postgrest
+        .from('messages')
+        .update({'channel_id': 2})
+        .eq('message', 'foo')
+        .execute();
 
-    final resMsg =
-        await postgrest.from('messages').select().filter('message', 'eq', 'foo').execute();
+    final resMsg = await postgrest
+        .from('messages')
+        .select()
+        .filter('message', 'eq', 'foo')
+        .execute();
     resMsg.data.forEach((rec) => expect(rec['channel_id'], 2));
   });
 
   test('basic delete', () async {
     await postgrest.from('messages').delete().eq('message', 'foo').execute();
 
-    final resMsg =
-        await postgrest.from('messages').select().filter('message', 'eq', 'foo').execute();
+    final resMsg = await postgrest
+        .from('messages')
+        .select()
+        .filter('message', 'eq', 'foo')
+        .execute();
     expect(resMsg.data.length, 0);
   });
 
@@ -107,19 +122,27 @@ void main() {
   });
 
   test('select with head:true, count: exact', () async {
-    final res =
-        await postgrest.from('users').select().execute(head: true, count: CountOption.exact);
+    final res = await postgrest
+        .from('users')
+        .select()
+        .execute(head: true, count: CountOption.exact);
     expect(res.data, null);
     expect(res.count, 4);
   });
 
   test('select with  count: planned', () async {
-    final res = await postgrest.from('users').select().execute(count: CountOption.exact);
+    final res = await postgrest
+        .from('users')
+        .select()
+        .execute(count: CountOption.exact);
     expect(res.count, const TypeMatcher<int>());
   });
 
   test('select with head:true, count: estimated', () async {
-    final res = await postgrest.from('users').select().execute(count: CountOption.exact);
+    final res = await postgrest
+        .from('users')
+        .select()
+        .execute(count: CountOption.exact);
     expect(res.count, const TypeMatcher<int>());
   });
 
@@ -135,7 +158,8 @@ void main() {
   });
 
   test('stored procedure with count: exact', () async {
-    final res = await postgrest.rpc('get_status').execute(count: CountOption.exact);
+    final res =
+        await postgrest.rpc('get_status').execute(count: CountOption.exact);
     expect(res.error, isNotNull);
     expect(res.error!.hint, isNotNull);
     expect(res.error!.message, isNotNull);

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -11,8 +11,11 @@ void main() {
   });
 
   test('not', () async {
-    final res =
-        await postgrest.from('users').select('status').not('status', 'eq', 'OFFLINE').execute();
+    final res = await postgrest
+        .from('users')
+        .select('status')
+        .not('status', 'eq', 'OFFLINE')
+        .execute();
     res.data.forEach((item) {
       expect(item['status'] != ('OFFLINE'), true);
     });
@@ -25,13 +28,17 @@ void main() {
         .or('status.eq.OFFLINE,username.eq.supabot')
         .execute();
     res.data.forEach((item) {
-      expect(item['username'] == ('supabot') || item['status'] == ('OFFLINE'), true);
+      expect(item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
+          true);
     });
   });
 
   test('eq', () async {
-    final res =
-        await postgrest.from('users').select('username').eq('username', 'supabot').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .eq('username', 'supabot')
+        .execute();
 
     res.data.forEach((item) {
       expect(item['username'] == ('supabot'), true);
@@ -39,52 +46,65 @@ void main() {
   });
 
   test('neq', () async {
-    final res =
-        await postgrest.from('users').select('username').neq('username', 'supabot').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .neq('username', 'supabot')
+        .execute();
     res.data.forEach((item) {
       expect(item['username'] == ('supabot'), false);
     });
   });
 
   test('gt', () async {
-    final res = await postgrest.from('messages').select('id').gt('id', 1).execute();
+    final res =
+        await postgrest.from('messages').select('id').gt('id', 1).execute();
     res.data.forEach((item) {
       expect(item['id'] > 1, true);
     });
   });
 
   test('gte', () async {
-    final res = await postgrest.from('messages').select('id').gte('id', 1).execute();
+    final res =
+        await postgrest.from('messages').select('id').gte('id', 1).execute();
     res.data.forEach((item) {
       expect(item['id'] < 1, false);
     });
   });
 
   test('lt', () async {
-    final res = await postgrest.from('messages').select('id').lt('id', 2).execute();
+    final res =
+        await postgrest.from('messages').select('id').lt('id', 2).execute();
     res.data.forEach((item) {
       expect(item['id'] < 2, true);
     });
   });
 
   test('lte', () async {
-    final res = await postgrest.from('messages').select('id').lte('id', 2).execute();
+    final res =
+        await postgrest.from('messages').select('id').lte('id', 2).execute();
     res.data.forEach((item) {
       expect(item['id'] > 2, false);
     });
   });
 
   test('like', () async {
-    final res =
-        await postgrest.from('users').select('username').like('username', '%supa%').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .like('username', '%supa%')
+        .execute();
     res.data.forEach((item) {
       expect(item['username'].contains('supa'), true);
     });
   });
 
   test('ilike', () async {
-    final res =
-        await postgrest.from('users').select('username').ilike('username', '%SUPA%').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .ilike('username', '%SUPA%')
+        .execute();
     res.data.forEach((item) {
       final user = item['username'].toLowerCase();
       expect(user.contains('supa'), true);
@@ -92,7 +112,11 @@ void main() {
   });
 
   test('is', () async {
-    final res = await postgrest.from('users').select('data').is_('data', null).execute();
+    final res = await postgrest
+        .from('users')
+        .select('data')
+        .is_('data', null)
+        .execute();
     res.data.forEach((item) {
       expect(item['data'], null);
     });
@@ -109,8 +133,11 @@ void main() {
   });
 
   test('contains', () async {
-    final res =
-        await postgrest.from('users').select('username').contains('age_range', '[1,2)').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .contains('age_range', '[1,2)')
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
@@ -124,30 +151,42 @@ void main() {
   });
 
   test('rangeLt', () async {
-    final res =
-        await postgrest.from('users').select('username').rangeLt('age_range', '[2,25)').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .rangeLt('age_range', '[2,25)')
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 
   test('rangeGt', () async {
-    final res =
-        await postgrest.from('users').select('age_range').rangeGt('age_range', '[2,25)').execute();
+    final res = await postgrest
+        .from('users')
+        .select('age_range')
+        .rangeGt('age_range', '[2,25)')
+        .execute();
     res.data.forEach((item) {
       expect(item['username'] != 'supabot', true);
     });
   });
 
   test('rangeGte', () async {
-    final res =
-        await postgrest.from('users').select('age_range').rangeGte('age_range', '[2,25)').execute();
+    final res = await postgrest
+        .from('users')
+        .select('age_range')
+        .rangeGte('age_range', '[2,25)')
+        .execute();
     res.data.forEach((item) {
       expect(item['username'] != 'supabot', true);
     });
   });
 
   test('rangeLte', () async {
-    final res =
-        await postgrest.from('users').select('username').rangeLte('age_range', '[2,25)').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .rangeLte('age_range', '[2,25)')
+        .execute();
     res.data.forEach((item) {
       expect(item['username'] == 'supabot', true);
     });
@@ -163,8 +202,11 @@ void main() {
   });
 
   test('overlaps', () async {
-    final res =
-        await postgrest.from('users').select('username').overlaps('age_range', '[2,25)').execute();
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .overlaps('age_range', '[2,25)')
+        .execute();
     expect(res.data[0]['username'], 'dragarcia');
   });
 
@@ -181,7 +223,8 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('username')
-        .textSearch('catchphrase', "'fat' & 'cat'", config: 'english', type: TextSearchType.plain)
+        .textSearch('catchphrase', "'fat' & 'cat'",
+            config: 'english', type: TextSearchType.plain)
         .execute();
     expect(res.data[0]['username'], 'supabot');
   });
@@ -190,7 +233,8 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('username')
-        .textSearch('catchphrase', 'cat', config: 'english', type: TextSearchType.phrase)
+        .textSearch('catchphrase', 'cat',
+            config: 'english', type: TextSearchType.phrase)
         .execute();
     expect(res.data.length, 2);
   });
@@ -219,8 +263,11 @@ void main() {
   });
 
   test('filter', () async {
-    final res =
-        await postgrest.from('users').select().filter('username', 'eq', 'supabot').execute();
+    final res = await postgrest
+        .from('users')
+        .select()
+        .filter('username', 'eq', 'supabot')
+        .execute();
     expect(res.data[0]['username'], 'supabot');
   });
 

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -10,13 +10,19 @@ void main() {
   });
 
   test('order', () async {
-    final res = await postgrest.from('users').select().order('username').execute();
+    final res =
+        await postgrest.from('users').select().order('username').execute();
     expect(res.data[1]['username'], 'kiwicopple');
     expect(res.data[3]['username'], 'awailas');
   });
 
   test('order on multiple columns', () async {
-    final res = await postgrest.from('users').select().order('catchphrase', ascending: true).order('username').execute();
+    final res = await postgrest
+        .from('users')
+        .select()
+        .order('catchphrase', ascending: true)
+        .order('username')
+        .execute();
     expect(res.data[0]['username'], 'kiwicopple');
     expect(res.data[2]['username'], 'supabot');
     expect(res.data[3]['username'], 'dragarcia');
@@ -30,7 +36,8 @@ void main() {
   test('range', () async {
     const from = 1;
     const to = 3;
-    final res = await postgrest.from('users').select().range(from, to).execute();
+    final res =
+        await postgrest.from('users').select().range(from, to).execute();
     //from -1 so that the index is included
     expect(res.data.length, to - (from - 1));
   });
@@ -38,13 +45,15 @@ void main() {
   test('range 1-1', () async {
     const from = 1;
     const to = 1;
-    final res = await postgrest.from('users').select().range(from, to).execute();
+    final res =
+        await postgrest.from('users').select().range(from, to).execute();
     //from -1 so that the index is included
     expect(res.data.length, to - (from - 1));
   });
 
   test('single', () async {
-    final res = await postgrest.from('users').select().limit(1).single().execute();
+    final res =
+        await postgrest.from('users').select().limit(1).single().execute();
     expect(res.data['username'], 'supabot');
     expect(res.data['status'], 'ONLINE');
   });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated Github actions to check letters per line and lint rules. 

Related to https://github.com/supabase/supabase-dart/pull/28

## What is the current behavior?

Github actions does not check for letters per line and lint

## What is the new behavior?

Github actions will check if letters per line for every file is 80 and there are no lint errors