### PR TITLE
fix: Using `in` filter within `not` filter

### DIFF
--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -18,7 +18,11 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// postgrest.from('users').select().not('status', 'eq', 'OFFLINE')
   /// ```
   PostgrestFilterBuilder not(String column, String operator, dynamic value) {
-    appendSearchParams(column, 'not.$operator.$value');
+    if (value is List) {
+      appendSearchParams(column, 'not.$operator.(${_cleanFilterArray(value)})');
+    } else {
+      appendSearchParams(column, 'not.$operator.$value');
+    }
     return this;
   }
 

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -20,6 +20,17 @@ void main() {
     });
   });
 
+  test('not with in filter', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .not('username', 'in', ['supabot', 'kiwicopple']).execute();
+    res.data.forEach((item) {
+      expect(item['username'] != ('supabot'), true);
+      expect(item['username'] != ('kiwicopple'), true);
+    });
+  });
+
   test('or', () async {
     final res = await postgrest
         .from('users')


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR removes the bug preventing users from using `in` filter within `not` filter. 
related to https://github.com/supabase/postgrest-dart/issues/36

## What is the current behavior?

```dart
supabase.from('users').select().not('id', 'in', ['foo', 'bar']).execute();
```
 Results in `failed to parse filter (not.in.[])" (line 1, column 8)` error. 

## What is the new behavior?

Using `in` filter within `not` is supported. 
