### PR TITLE
Update filter for not

### DIFF
--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -19,7 +19,17 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```
   PostgrestFilterBuilder not(String column, String operator, dynamic value) {
     if (value is List) {
-      appendSearchParams(column, 'not.$operator.(${_cleanFilterArray(value)})');
+      if (value is List<int> || value is List<double> || value is List<num>) {
+        appendSearchParams(
+          column,
+          'not.$operator.(${value.map((s) => '$s').join(',')})',
+        );
+      } else {
+        appendSearchParams(
+          column,
+          'not.$operator.(${_cleanFilterArray(value)})',
+        );
+      }
     } else {
       appendSearchParams(column, 'not.$operator.$value');
     }


### PR DESCRIPTION
Currently, all the items in the list are wrapped within quotes ("). Tho, if the item is a number, it should not be wrapped in them.

I have only changed the `not` filter because this is the only one I have experience with, but I guess this should be handled at `_cleanFilterArray`. What do you think?

#32