### PR TITLE
 add toString method to PostgrestError

### DIFF
--- a/lib/src/postgrest_error.dart
+++ b/lib/src/postgrest_error.dart
@@ -25,4 +25,10 @@ class PostgrestError {
         'hint': hint,
         'code': code,
       };
+
+  @override
+  String toString() {
+    return 'PostgrestError{message: $message, '
+        'details: $details, hint: $hint, code: $code}';
+  }
 }

--- a/lib/src/postgrest_error.dart
+++ b/lib/src/postgrest_error.dart
@@ -2,33 +2,33 @@
 class PostgrestError {
   PostgrestError({
     required this.message,
+    this.code,
     this.details,
     this.hint,
-    this.code,
   });
 
-  String message;
-  dynamic details;
-  String? hint;
-  String? code;
+  final String message;
+  final String? code;
+  final dynamic details;
+  final String? hint;
 
   factory PostgrestError.fromJson(Map<String, dynamic> json) => PostgrestError(
         message: json['message'] as String,
+        code: json['code'] as String?,
         details: json['details'] as dynamic,
         hint: json['hint'] as String?,
-        code: json['code'] as String?,
       );
 
   Map<String, dynamic> toJson() => {
         'message': message,
+        'code': code,
         'details': details,
         'hint': hint,
-        'code': code,
       };
 
   @override
   String toString() {
-    return 'PostgrestError{message: $message, '
-        'details: ${details?.toString()}, hint: $hint, code: $code}';
+    return 'PostgrestError(message: $message, '
+        'code: $code, details: ${details?.toString()}, hint: $hint)';
   }
 }

--- a/lib/src/postgrest_error.dart
+++ b/lib/src/postgrest_error.dart
@@ -29,6 +29,6 @@ class PostgrestError {
   @override
   String toString() {
     return 'PostgrestError{message: $message, '
-        'details: $details, hint: $hint, code: $code}';
+        'details: ${details?.toString()}, hint: $hint, code: $code}';
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (kinda)

## What is the current behavior?

Currently, logging the error only shows instance of `PostgrestError`.

## What is the new behavior?

When logging supabase errors, the `toString` will be invoked and that will result in better debugging.

## Additional context
N/A
