### PR TITLE
feat: added x-client-info header with manually updating version number

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,3 @@
+import 'package:postgrest/src/version.dart';
+
+const defaultHeaders = {'X-Client-Info': 'postgrest-dart/$version'};

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -1,3 +1,5 @@
+import 'package:postgrest/src/constants.dart';
+
 import 'postgrest_query_builder.dart';
 import 'postgrest_rpc_builder.dart';
 import 'postgrest_transform_builder.dart';
@@ -19,7 +21,7 @@ class PostgrestClient {
     this.url, {
     Map<String, String>? headers,
     this.schema,
-  }) : headers = headers ?? {};
+  }) : headers = {...defaultHeaders, if (headers != null) ...headers};
 
   /// Authenticates the request with JWT.
   PostgrestClient auth(String token) {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,1 @@
+const version = '0.1.6';

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -38,6 +38,13 @@ void main() {
     expect(postgrest.from('users').select().headers['apikey'], 'foo');
   });
 
+  test('override X-Client-Info', () async {
+    final postgrest = PostgrestClient(rootUrl,
+        headers: {'X-Client-Info': 'supabase-dart/0.0.0'});
+    expect(postgrest.from('users').select().headers['X-Client-Info'],
+        'supabase-dart/0.0.0');
+  });
+
   test('auth', () async {
     postgrest = PostgrestClient(rootUrl).auth('foo');
     expect(postgrest.from('users').select().headers['Authorization'],


### PR DESCRIPTION
## What kind of change does this PR introduce?

It adds `x-content-info` header to debug on server side more easily. 

For right now, we will have to update the version number in `version.dart` manually it seems like. 

Related https://github.com/supabase/postgrest-dart/issues/40