### PR TITLE
chore: updated github action to use official dart-lang action to setup dart

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Test
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [master]
@@ -17,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ["12"]
+        sdk: [stable, beta, dev]
 
     runs-on: ${{ matrix.os }}
 
@@ -25,7 +22,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Dart
-        uses: cedx/setup-dart@v2
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: pub get

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }}
+    name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }} / SDK ${{ matrix.sdk }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/example/main.dart
+++ b/example/main.dart
@@ -4,8 +4,11 @@ import 'package:postgrest/postgrest.dart';
 dynamic main() async {
   const supabaseUrl = '';
   const supabaseKey = '';
-  final client = PostgrestClient('$supabaseUrl/rest/v1',
-      headers: {'apikey': supabaseKey}, schema: 'public');
+  final client = PostgrestClient(
+    '$supabaseUrl/rest/v1',
+    headers: {'apikey': supabaseKey},
+    schema: 'public',
+  );
 
   try {
     final response = await client

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -144,8 +144,9 @@ abstract class PostgrestBuilder {
         }
       } else {
         error = PostgrestError(
-            code: response.statusCode.toString(),
-            message: 'Error in Postgrest response for method HEAD');
+          code: response.statusCode.toString(),
+          message: 'Error in Postgrest response for method HEAD',
+        );
       }
 
       return PostgrestResponse(
@@ -159,7 +160,9 @@ abstract class PostgrestBuilder {
   /// 'Results contain 0 rows' then
   /// return PostgrestResponse with null data
   PostgrestResponse handleMaybeEmptyError(
-      http.Response response, PostgrestError error) {
+    http.Response response,
+    PostgrestError error,
+  ) {
     if (error.details is String &&
         error.details.toString().contains('Results contain 0 rows')) {
       return PostgrestResponse(

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -65,8 +65,10 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
         ? 'return=${returning.name()},resolution=merge-duplicates'
         : 'return=${returning.name()}';
     if (onConflict != null) {
-      url = url.replace(
-          queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
+      url = url.replace(queryParameters: {
+        'on_conflict': onConflict,
+        ...url.queryParameters,
+      });
     }
     body = values;
     return this;
@@ -90,8 +92,10 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     headers['Prefer'] =
         'return=${returning.name()},resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates';
     if (onConflict != null) {
-      url = url.replace(
-          queryParameters: {'on_conflict': onConflict, ...url.queryParameters});
+      url = url.replace(queryParameters: {
+        'on_conflict': onConflict,
+        ...url.queryParameters,
+      });
     }
     body = values;
     return this;

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -65,10 +65,12 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
         ? 'return=${returning.name()},resolution=merge-duplicates'
         : 'return=${returning.name()}';
     if (onConflict != null) {
-      url = url.replace(queryParameters: {
-        'on_conflict': onConflict,
-        ...url.queryParameters,
-      });
+      url = url.replace(
+        queryParameters: {
+          'on_conflict': onConflict,
+          ...url.queryParameters,
+        },
+      );
     }
     body = values;
     return this;
@@ -92,10 +94,12 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     headers['Prefer'] =
         'return=${returning.name()},resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates';
     if (onConflict != null) {
-      url = url.replace(queryParameters: {
-        'on_conflict': onConflict,
-        ...url.queryParameters,
-      });
+      url = url.replace(
+        queryParameters: {
+          'on_conflict': onConflict,
+          ...url.queryParameters,
+        },
+      );
     }
     body = values;
     return this;

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -42,8 +42,12 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder {
   /// postgrest.from('users').select().order('username', ascending: false)
   /// postgrest.from('users').select('messages(*)').order('channel_id', foreignTable: 'messages', ascending: false)
   /// ```
-  PostgrestTransformBuilder order(String column,
-      {bool ascending = false, bool nullsFirst = false, String? foreignTable}) {
+  PostgrestTransformBuilder order(
+    String column, {
+    bool ascending = false,
+    bool nullsFirst = false,
+    String? foreignTable,
+  }) {
     final key = foreignTable == null ? 'order' : '"$foreignTable".order';
     final existingOrder = url.queryParameters[key];
     final value = '${existingOrder == null ? '' : '$existingOrder,'}'

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
 
 void main() {
   const rootUrl = 'http://localhost:3000';
@@ -39,16 +39,20 @@ void main() {
   });
 
   test('override X-Client-Info', () async {
-    final postgrest = PostgrestClient(rootUrl,
-        headers: {'X-Client-Info': 'supabase-dart/0.0.0'});
+    final postgrest = PostgrestClient(
+      rootUrl,
+      headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
+    );
     expect(postgrest.from('users').select().headers['X-Client-Info'],
         'supabase-dart/0.0.0');
   });
 
   test('auth', () async {
     postgrest = PostgrestClient(rootUrl).auth('foo');
-    expect(postgrest.from('users').select().headers['Authorization'],
-        'Bearer foo');
+    expect(
+      postgrest.from('users').select().headers['Authorization'],
+      'Bearer foo',
+    );
   });
 
   test('switch schema', () async {
@@ -59,8 +63,9 @@ void main() {
 
   test('on_conflict upsert', () async {
     final res = await postgrest.from('users').upsert(
-        {'username': 'dragarcia', 'status': 'OFFLINE'},
-        onConflict: 'username').execute();
+      {'username': 'dragarcia', 'status': 'OFFLINE'},
+      onConflict: 'username',
+    ).execute();
     expect(res.data[0]['status'], 'OFFLINE');
   });
 
@@ -78,8 +83,11 @@ void main() {
   });
 
   test('ignoreDuplicates upsert', () async {
-    final res = await postgrest.from('users').upsert({'username': 'dragarcia'},
-        onConflict: 'username', ignoreDuplicates: true).execute();
+    final res = await postgrest.from('users').upsert(
+      {'username': 'dragarcia'},
+      onConflict: 'username',
+      ignoreDuplicates: true,
+    ).execute();
     expect(res.data.length, 0);
     expect(res.error, isNull);
   });
@@ -187,7 +195,9 @@ void main() {
   test('insert with count: exact', () async {
     final res = await postgrest.from('users').upsert(
         {'username': 'countexact', 'status': 'OFFLINE'},
-        onConflict: 'username').execute(count: CountOption.exact);
+        onConflict: 'username').execute(
+      count: CountOption.exact,
+    );
     expect(res.count, 1);
   });
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -43,8 +43,10 @@ void main() {
       rootUrl,
       headers: {'X-Client-Info': 'supabase-dart/0.0.0'},
     );
-    expect(postgrest.from('users').select().headers['X-Client-Info'],
-        'supabase-dart/0.0.0');
+    expect(
+      postgrest.from('users').select().headers['X-Client-Info'],
+      'supabase-dart/0.0.0',
+    );
   });
 
   test('auth', () async {
@@ -194,8 +196,9 @@ void main() {
 
   test('insert with count: exact', () async {
     final res = await postgrest.from('users').upsert(
-        {'username': 'countexact', 'status': 'OFFLINE'},
-        onConflict: 'username').execute(
+      {'username': 'countexact', 'status': 'OFFLINE'},
+      onConflict: 'username',
+    ).execute(
       count: CountOption.exact,
     );
     expect(res.count, 1);

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
 
 void main() {
   const rootUrl = 'http://localhost:3000';
@@ -38,8 +38,10 @@ void main() {
         .or('status.eq.OFFLINE,username.eq.supabot')
         .execute();
     res.data.forEach((item) {
-      expect(item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
-          true);
+      expect(
+        item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
+        true,
+      );
     });
   });
 
@@ -233,8 +235,12 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('username')
-        .textSearch('catchphrase', "'fat' & 'cat'",
-            config: 'english', type: TextSearchType.plain)
+        .textSearch(
+          'catchphrase',
+          "'fat' & 'cat'",
+          config: 'english',
+          type: TextSearchType.plain,
+        )
         .execute();
     expect(res.data[0]['username'], 'supabot');
   });
@@ -243,8 +249,12 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('username')
-        .textSearch('catchphrase', 'cat',
-            config: 'english', type: TextSearchType.phrase)
+        .textSearch(
+          'catchphrase',
+          'cat',
+          config: 'english',
+          type: TextSearchType.phrase,
+        )
         .execute();
     expect(res.data.length, 2);
   });
@@ -253,8 +263,12 @@ void main() {
     final res = await postgrest
         .from('users')
         .select('username')
-        .textSearch('catchphrase', "'fat' & 'cat'",
-            config: 'english', type: TextSearchType.websearch)
+        .textSearch(
+          'catchphrase',
+          "'fat' & 'cat'",
+          config: 'english',
+          type: TextSearchType.websearch,
+        )
         .execute();
     expect(res.data[0]['username'], 'supabot');
   });

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
 
 void main() {
   const rootUrl = 'http://localhost:3000';

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:postgrest/postgrest.dart';
+import 'package:test/test.dart';
 
 void main() {
   const rootUrl = 'http://localhost:3000';


### PR DESCRIPTION
## What kind of change does this PR introduce?

The [Github action we used to use for Dart language](https://github.com/cedx/setup-dart) is now deprecated, and there is a [one published by the official dart language team](https://github.com/marketplace/actions/setup-dart-sdk), so using that one instead of the current one. 

This PR will include any analysis error fix that is raised with the newest stable dart language `2.14.0`. 

## What is the current behavior?

Using a deprecated Github Action.

## What is the new behavior?

Using Github Action published by the official dart lang team and also testing stable, beta, dev version of dart language. 
