### PR TITLE
fix: Add support for filter on rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.8]
+
+- fix: bug where `filter` is not available on `rpc()`
+
 ## [0.1.7]
 
 - feat: added `X-Client-Info` header

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -1,8 +1,8 @@
 import 'package:postgrest/src/constants.dart';
+import 'package:postgrest/src/postgrest_filter_builder.dart';
 
 import 'postgrest_query_builder.dart';
 import 'postgrest_rpc_builder.dart';
-import 'postgrest_transform_builder.dart';
 
 /// A PostgREST api client written in Dartlang. The goal of this library is to make an "ORM-like" restful interface.
 class PostgrestClient {
@@ -40,7 +40,7 @@ class PostgrestClient {
   /// ```dart
   /// postgrest.rpc('get_status', params: {'name_param': 'supabot'})
   /// ```
-  PostgrestTransformBuilder rpc(String fn, {Map? params}) {
+  PostgrestFilterBuilder rpc(String fn, {Map? params}) {
     final url = '${this.url}/rpc/$fn';
     return PostgrestRpcBuilder(url, headers: headers, schema: schema)
         .rpc(params);

--- a/lib/src/postgrest_rpc_builder.dart
+++ b/lib/src/postgrest_rpc_builder.dart
@@ -1,5 +1,5 @@
+import 'package:postgrest/postgrest.dart';
 import 'postgrest_builder.dart';
-import 'postgrest_transform_builder.dart';
 
 class PostgrestRpcBuilder extends PostgrestBuilder {
   PostgrestRpcBuilder(
@@ -13,9 +13,9 @@ class PostgrestRpcBuilder extends PostgrestBuilder {
         );
 
   /// Performs stored procedures on the database.
-  PostgrestTransformBuilder rpc([dynamic params]) {
+  PostgrestFilterBuilder rpc([dynamic params]) {
     method = 'POST';
     body = params;
-    return PostgrestTransformBuilder(this);
+    return PostgrestFilterBuilder(this);
   }
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.7';
+const version = '0.1.8';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 0.1.7
+version: 0.1.8
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/postgrest-dart'
 

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -9,297 +9,309 @@ void main() {
     postgrest = PostgrestClient(rootUrl);
   });
 
-  test('not', () async {
-    final res = await postgrest
-        .from('users')
-        .select('status')
-        .not('status', 'eq', 'OFFLINE')
-        .execute();
-    res.data.forEach((item) {
-      expect(item['status'] != ('OFFLINE'), true);
+  group('select', () {
+    test('not', () async {
+      final res = await postgrest
+          .from('users')
+          .select('status')
+          .not('status', 'eq', 'OFFLINE')
+          .execute();
+      res.data.forEach((item) {
+        expect(item['status'] != ('OFFLINE'), true);
+      });
+    });
+
+    test('not with in filter', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .not('username', 'in', ['supabot', 'kiwicopple']).execute();
+      res.data.forEach((item) {
+        expect(item['username'] != ('supabot'), true);
+        expect(item['username'] != ('kiwicopple'), true);
+      });
+    });
+
+    test('or', () async {
+      final res = await postgrest
+          .from('users')
+          .select('status, username')
+          .or('status.eq.OFFLINE,username.eq.supabot')
+          .execute();
+      res.data.forEach((item) {
+        expect(
+          item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
+          true,
+        );
+      });
+    });
+
+    test('eq', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .eq('username', 'supabot')
+          .execute();
+
+      res.data.forEach((item) {
+        expect(item['username'] == ('supabot'), true);
+      });
+    });
+
+    test('neq', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .neq('username', 'supabot')
+          .execute();
+      res.data.forEach((item) {
+        expect(item['username'] == ('supabot'), false);
+      });
+    });
+
+    test('gt', () async {
+      final res =
+          await postgrest.from('messages').select('id').gt('id', 1).execute();
+      res.data.forEach((item) {
+        expect(item['id'] > 1, true);
+      });
+    });
+
+    test('gte', () async {
+      final res =
+          await postgrest.from('messages').select('id').gte('id', 1).execute();
+      res.data.forEach((item) {
+        expect(item['id'] < 1, false);
+      });
+    });
+
+    test('lt', () async {
+      final res =
+          await postgrest.from('messages').select('id').lt('id', 2).execute();
+      res.data.forEach((item) {
+        expect(item['id'] < 2, true);
+      });
+    });
+
+    test('lte', () async {
+      final res =
+          await postgrest.from('messages').select('id').lte('id', 2).execute();
+      res.data.forEach((item) {
+        expect(item['id'] > 2, false);
+      });
+    });
+
+    test('like', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .like('username', '%supa%')
+          .execute();
+      res.data.forEach((item) {
+        expect(item['username'].contains('supa'), true);
+      });
+    });
+
+    test('ilike', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .ilike('username', '%SUPA%')
+          .execute();
+      res.data.forEach((item) {
+        final user = item['username'].toLowerCase();
+        expect(user.contains('supa'), true);
+      });
+    });
+
+    test('is', () async {
+      final res = await postgrest
+          .from('users')
+          .select('data')
+          .is_('data', null)
+          .execute();
+      res.data.forEach((item) {
+        expect(item['data'], null);
+      });
+    });
+
+    test('in', () async {
+      final res = await postgrest
+          .from('users')
+          .select('status')
+          .in_('status', ['ONLINE', 'OFFLINE']).execute();
+      res.data.forEach((item) {
+        expect(item['status'] == 'ONLINE' || item['status'] == 'OFFLINE', true);
+      });
+    });
+
+    test('contains', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .contains('age_range', '[1,2)')
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('containedBy', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .containedBy('age_range', '[1,2)')
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('rangeLt', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .rangeLt('age_range', '[2,25)')
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('rangeGt', () async {
+      final res = await postgrest
+          .from('users')
+          .select('age_range')
+          .rangeGt('age_range', '[2,25)')
+          .execute();
+      res.data.forEach((item) {
+        expect(item['username'] != 'supabot', true);
+      });
+    });
+
+    test('rangeGte', () async {
+      final res = await postgrest
+          .from('users')
+          .select('age_range')
+          .rangeGte('age_range', '[2,25)')
+          .execute();
+      res.data.forEach((item) {
+        expect(item['username'] != 'supabot', true);
+      });
+    });
+
+    test('rangeLte', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .rangeLte('age_range', '[2,25)')
+          .execute();
+      res.data.forEach((item) {
+        expect(item['username'] == 'supabot', true);
+      });
+    });
+
+    test('rangeAdjacent', () async {
+      final res = await postgrest
+          .from('users')
+          .select('age_range')
+          .rangeAdjacent('age_range', '[2,25)')
+          .execute();
+      expect(res.data.length, 3);
+    });
+
+    test('overlaps', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .overlaps('age_range', '[2,25)')
+          .execute();
+      expect(res.data[0]['username'], 'dragarcia');
+    });
+
+    test('textSearch', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .textSearch('catchphrase', "'fat' & 'cat'", config: 'english')
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('textSearch with plainto_tsquery', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .textSearch(
+            'catchphrase',
+            "'fat' & 'cat'",
+            config: 'english',
+            type: TextSearchType.plain,
+          )
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('textSearch with phraseto_tsquery', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .textSearch(
+            'catchphrase',
+            'cat',
+            config: 'english',
+            type: TextSearchType.phrase,
+          )
+          .execute();
+      expect(res.data.length, 2);
+    });
+
+    test('textSearch with websearch_to_tsquery', () async {
+      final res = await postgrest
+          .from('users')
+          .select('username')
+          .textSearch(
+            'catchphrase',
+            "'fat' & 'cat'",
+            config: 'english',
+            type: TextSearchType.websearch,
+          )
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('multiple filters', () async {
+      final res = await postgrest
+          .from('users')
+          .select()
+          .eq('username', 'supabot')
+          .is_('data', null)
+          .overlaps('age_range', '[1,2)')
+          .eq('status', 'ONLINE')
+          .textSearch('catchphrase', 'cat')
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('filter', () async {
+      final res = await postgrest
+          .from('users')
+          .select()
+          .filter('username', 'eq', 'supabot')
+          .execute();
+      expect(res.data[0]['username'], 'supabot');
+    });
+
+    test('match', () async {
+      final res = await postgrest
+          .from('users')
+          .select()
+          .match({'username': 'supabot', 'status': 'ONLINE'}).execute();
+      expect(res.data[0]['username'], 'supabot');
     });
   });
 
-  test('not with in filter', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .not('username', 'in', ['supabot', 'kiwicopple']).execute();
-    res.data.forEach((item) {
-      expect(item['username'] != ('supabot'), true);
-      expect(item['username'] != ('kiwicopple'), true);
+  group('rpc', () {
+    test('not', () async {
+      final res = await postgrest
+          .rpc('get_username_and_status', params: {'name_param': 'supabot'})
+          .neq('status', 'ONLINE')
+          .execute();
+      expect(res.data.isEmpty, true);
     });
-  });
-
-  test('or', () async {
-    final res = await postgrest
-        .from('users')
-        .select('status, username')
-        .or('status.eq.OFFLINE,username.eq.supabot')
-        .execute();
-    res.data.forEach((item) {
-      expect(
-        item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
-        true,
-      );
-    });
-  });
-
-  test('eq', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .eq('username', 'supabot')
-        .execute();
-
-    res.data.forEach((item) {
-      expect(item['username'] == ('supabot'), true);
-    });
-  });
-
-  test('neq', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .neq('username', 'supabot')
-        .execute();
-    res.data.forEach((item) {
-      expect(item['username'] == ('supabot'), false);
-    });
-  });
-
-  test('gt', () async {
-    final res =
-        await postgrest.from('messages').select('id').gt('id', 1).execute();
-    res.data.forEach((item) {
-      expect(item['id'] > 1, true);
-    });
-  });
-
-  test('gte', () async {
-    final res =
-        await postgrest.from('messages').select('id').gte('id', 1).execute();
-    res.data.forEach((item) {
-      expect(item['id'] < 1, false);
-    });
-  });
-
-  test('lt', () async {
-    final res =
-        await postgrest.from('messages').select('id').lt('id', 2).execute();
-    res.data.forEach((item) {
-      expect(item['id'] < 2, true);
-    });
-  });
-
-  test('lte', () async {
-    final res =
-        await postgrest.from('messages').select('id').lte('id', 2).execute();
-    res.data.forEach((item) {
-      expect(item['id'] > 2, false);
-    });
-  });
-
-  test('like', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .like('username', '%supa%')
-        .execute();
-    res.data.forEach((item) {
-      expect(item['username'].contains('supa'), true);
-    });
-  });
-
-  test('ilike', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .ilike('username', '%SUPA%')
-        .execute();
-    res.data.forEach((item) {
-      final user = item['username'].toLowerCase();
-      expect(user.contains('supa'), true);
-    });
-  });
-
-  test('is', () async {
-    final res = await postgrest
-        .from('users')
-        .select('data')
-        .is_('data', null)
-        .execute();
-    res.data.forEach((item) {
-      expect(item['data'], null);
-    });
-  });
-
-  test('in', () async {
-    final res = await postgrest
-        .from('users')
-        .select('status')
-        .in_('status', ['ONLINE', 'OFFLINE']).execute();
-    res.data.forEach((item) {
-      expect(item['status'] == 'ONLINE' || item['status'] == 'OFFLINE', true);
-    });
-  });
-
-  test('contains', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .contains('age_range', '[1,2)')
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('containedBy', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .containedBy('age_range', '[1,2)')
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('rangeLt', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .rangeLt('age_range', '[2,25)')
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('rangeGt', () async {
-    final res = await postgrest
-        .from('users')
-        .select('age_range')
-        .rangeGt('age_range', '[2,25)')
-        .execute();
-    res.data.forEach((item) {
-      expect(item['username'] != 'supabot', true);
-    });
-  });
-
-  test('rangeGte', () async {
-    final res = await postgrest
-        .from('users')
-        .select('age_range')
-        .rangeGte('age_range', '[2,25)')
-        .execute();
-    res.data.forEach((item) {
-      expect(item['username'] != 'supabot', true);
-    });
-  });
-
-  test('rangeLte', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .rangeLte('age_range', '[2,25)')
-        .execute();
-    res.data.forEach((item) {
-      expect(item['username'] == 'supabot', true);
-    });
-  });
-
-  test('rangeAdjacent', () async {
-    final res = await postgrest
-        .from('users')
-        .select('age_range')
-        .rangeAdjacent('age_range', '[2,25)')
-        .execute();
-    expect(res.data.length, 3);
-  });
-
-  test('overlaps', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .overlaps('age_range', '[2,25)')
-        .execute();
-    expect(res.data[0]['username'], 'dragarcia');
-  });
-
-  test('textSearch', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .textSearch('catchphrase', "'fat' & 'cat'", config: 'english')
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('textSearch with plainto_tsquery', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .textSearch(
-          'catchphrase',
-          "'fat' & 'cat'",
-          config: 'english',
-          type: TextSearchType.plain,
-        )
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('textSearch with phraseto_tsquery', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .textSearch(
-          'catchphrase',
-          'cat',
-          config: 'english',
-          type: TextSearchType.phrase,
-        )
-        .execute();
-    expect(res.data.length, 2);
-  });
-
-  test('textSearch with websearch_to_tsquery', () async {
-    final res = await postgrest
-        .from('users')
-        .select('username')
-        .textSearch(
-          'catchphrase',
-          "'fat' & 'cat'",
-          config: 'english',
-          type: TextSearchType.websearch,
-        )
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('multiple filters', () async {
-    final res = await postgrest
-        .from('users')
-        .select()
-        .eq('username', 'supabot')
-        .is_('data', null)
-        .overlaps('age_range', '[1,2)')
-        .eq('status', 'ONLINE')
-        .textSearch('catchphrase', 'cat')
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('filter', () async {
-    final res = await postgrest
-        .from('users')
-        .select()
-        .filter('username', 'eq', 'supabot')
-        .execute();
-    expect(res.data[0]['username'], 'supabot');
-  });
-
-  test('match', () async {
-    final res = await postgrest
-        .from('users')
-        .select()
-        .match({'username': 'supabot', 'status': 'ONLINE'}).execute();
-    expect(res.data[0]['username'], 'supabot');
   });
 }

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -9,309 +9,305 @@ void main() {
     postgrest = PostgrestClient(rootUrl);
   });
 
-  group('select', () {
-    test('not', () async {
-      final res = await postgrest
-          .from('users')
-          .select('status')
-          .not('status', 'eq', 'OFFLINE')
-          .execute();
-      res.data.forEach((item) {
-        expect(item['status'] != ('OFFLINE'), true);
-      });
-    });
-
-    test('not with in filter', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .not('username', 'in', ['supabot', 'kiwicopple']).execute();
-      res.data.forEach((item) {
-        expect(item['username'] != ('supabot'), true);
-        expect(item['username'] != ('kiwicopple'), true);
-      });
-    });
-
-    test('or', () async {
-      final res = await postgrest
-          .from('users')
-          .select('status, username')
-          .or('status.eq.OFFLINE,username.eq.supabot')
-          .execute();
-      res.data.forEach((item) {
-        expect(
-          item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
-          true,
-        );
-      });
-    });
-
-    test('eq', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .eq('username', 'supabot')
-          .execute();
-
-      res.data.forEach((item) {
-        expect(item['username'] == ('supabot'), true);
-      });
-    });
-
-    test('neq', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .neq('username', 'supabot')
-          .execute();
-      res.data.forEach((item) {
-        expect(item['username'] == ('supabot'), false);
-      });
-    });
-
-    test('gt', () async {
-      final res =
-          await postgrest.from('messages').select('id').gt('id', 1).execute();
-      res.data.forEach((item) {
-        expect(item['id'] > 1, true);
-      });
-    });
-
-    test('gte', () async {
-      final res =
-          await postgrest.from('messages').select('id').gte('id', 1).execute();
-      res.data.forEach((item) {
-        expect(item['id'] < 1, false);
-      });
-    });
-
-    test('lt', () async {
-      final res =
-          await postgrest.from('messages').select('id').lt('id', 2).execute();
-      res.data.forEach((item) {
-        expect(item['id'] < 2, true);
-      });
-    });
-
-    test('lte', () async {
-      final res =
-          await postgrest.from('messages').select('id').lte('id', 2).execute();
-      res.data.forEach((item) {
-        expect(item['id'] > 2, false);
-      });
-    });
-
-    test('like', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .like('username', '%supa%')
-          .execute();
-      res.data.forEach((item) {
-        expect(item['username'].contains('supa'), true);
-      });
-    });
-
-    test('ilike', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .ilike('username', '%SUPA%')
-          .execute();
-      res.data.forEach((item) {
-        final user = item['username'].toLowerCase();
-        expect(user.contains('supa'), true);
-      });
-    });
-
-    test('is', () async {
-      final res = await postgrest
-          .from('users')
-          .select('data')
-          .is_('data', null)
-          .execute();
-      res.data.forEach((item) {
-        expect(item['data'], null);
-      });
-    });
-
-    test('in', () async {
-      final res = await postgrest
-          .from('users')
-          .select('status')
-          .in_('status', ['ONLINE', 'OFFLINE']).execute();
-      res.data.forEach((item) {
-        expect(item['status'] == 'ONLINE' || item['status'] == 'OFFLINE', true);
-      });
-    });
-
-    test('contains', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .contains('age_range', '[1,2)')
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('containedBy', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .containedBy('age_range', '[1,2)')
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('rangeLt', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .rangeLt('age_range', '[2,25)')
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('rangeGt', () async {
-      final res = await postgrest
-          .from('users')
-          .select('age_range')
-          .rangeGt('age_range', '[2,25)')
-          .execute();
-      res.data.forEach((item) {
-        expect(item['username'] != 'supabot', true);
-      });
-    });
-
-    test('rangeGte', () async {
-      final res = await postgrest
-          .from('users')
-          .select('age_range')
-          .rangeGte('age_range', '[2,25)')
-          .execute();
-      res.data.forEach((item) {
-        expect(item['username'] != 'supabot', true);
-      });
-    });
-
-    test('rangeLte', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .rangeLte('age_range', '[2,25)')
-          .execute();
-      res.data.forEach((item) {
-        expect(item['username'] == 'supabot', true);
-      });
-    });
-
-    test('rangeAdjacent', () async {
-      final res = await postgrest
-          .from('users')
-          .select('age_range')
-          .rangeAdjacent('age_range', '[2,25)')
-          .execute();
-      expect(res.data.length, 3);
-    });
-
-    test('overlaps', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .overlaps('age_range', '[2,25)')
-          .execute();
-      expect(res.data[0]['username'], 'dragarcia');
-    });
-
-    test('textSearch', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .textSearch('catchphrase', "'fat' & 'cat'", config: 'english')
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('textSearch with plainto_tsquery', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .textSearch(
-            'catchphrase',
-            "'fat' & 'cat'",
-            config: 'english',
-            type: TextSearchType.plain,
-          )
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('textSearch with phraseto_tsquery', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .textSearch(
-            'catchphrase',
-            'cat',
-            config: 'english',
-            type: TextSearchType.phrase,
-          )
-          .execute();
-      expect(res.data.length, 2);
-    });
-
-    test('textSearch with websearch_to_tsquery', () async {
-      final res = await postgrest
-          .from('users')
-          .select('username')
-          .textSearch(
-            'catchphrase',
-            "'fat' & 'cat'",
-            config: 'english',
-            type: TextSearchType.websearch,
-          )
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('multiple filters', () async {
-      final res = await postgrest
-          .from('users')
-          .select()
-          .eq('username', 'supabot')
-          .is_('data', null)
-          .overlaps('age_range', '[1,2)')
-          .eq('status', 'ONLINE')
-          .textSearch('catchphrase', 'cat')
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('filter', () async {
-      final res = await postgrest
-          .from('users')
-          .select()
-          .filter('username', 'eq', 'supabot')
-          .execute();
-      expect(res.data[0]['username'], 'supabot');
-    });
-
-    test('match', () async {
-      final res = await postgrest
-          .from('users')
-          .select()
-          .match({'username': 'supabot', 'status': 'ONLINE'}).execute();
-      expect(res.data[0]['username'], 'supabot');
+  test('not', () async {
+    final res = await postgrest
+        .from('users')
+        .select('status')
+        .not('status', 'eq', 'OFFLINE')
+        .execute();
+    res.data.forEach((item) {
+      expect(item['status'] != ('OFFLINE'), true);
     });
   });
 
-  group('rpc', () {
-    test('not', () async {
-      final res = await postgrest
-          .rpc('get_username_and_status', params: {'name_param': 'supabot'})
-          .neq('status', 'ONLINE')
-          .execute();
-      expect(res.data.isEmpty, true);
+  test('not with in filter', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .not('username', 'in', ['supabot', 'kiwicopple']).execute();
+    res.data.forEach((item) {
+      expect(item['username'] != ('supabot'), true);
+      expect(item['username'] != ('kiwicopple'), true);
     });
+  });
+
+  test('or', () async {
+    final res = await postgrest
+        .from('users')
+        .select('status, username')
+        .or('status.eq.OFFLINE,username.eq.supabot')
+        .execute();
+    res.data.forEach((item) {
+      expect(
+        item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
+        true,
+      );
+    });
+  });
+
+  test('eq', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .eq('username', 'supabot')
+        .execute();
+
+    res.data.forEach((item) {
+      expect(item['username'] == ('supabot'), true);
+    });
+  });
+
+  test('neq', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .neq('username', 'supabot')
+        .execute();
+    res.data.forEach((item) {
+      expect(item['username'] == ('supabot'), false);
+    });
+  });
+
+  test('gt', () async {
+    final res =
+        await postgrest.from('messages').select('id').gt('id', 1).execute();
+    res.data.forEach((item) {
+      expect(item['id'] > 1, true);
+    });
+  });
+
+  test('gte', () async {
+    final res =
+        await postgrest.from('messages').select('id').gte('id', 1).execute();
+    res.data.forEach((item) {
+      expect(item['id'] < 1, false);
+    });
+  });
+
+  test('lt', () async {
+    final res =
+        await postgrest.from('messages').select('id').lt('id', 2).execute();
+    res.data.forEach((item) {
+      expect(item['id'] < 2, true);
+    });
+  });
+
+  test('lte', () async {
+    final res =
+        await postgrest.from('messages').select('id').lte('id', 2).execute();
+    res.data.forEach((item) {
+      expect(item['id'] > 2, false);
+    });
+  });
+
+  test('like', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .like('username', '%supa%')
+        .execute();
+    res.data.forEach((item) {
+      expect(item['username'].contains('supa'), true);
+    });
+  });
+
+  test('ilike', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .ilike('username', '%SUPA%')
+        .execute();
+    res.data.forEach((item) {
+      final user = item['username'].toLowerCase();
+      expect(user.contains('supa'), true);
+    });
+  });
+
+  test('is', () async {
+    final res = await postgrest
+        .from('users')
+        .select('data')
+        .is_('data', null)
+        .execute();
+    res.data.forEach((item) {
+      expect(item['data'], null);
+    });
+  });
+
+  test('in', () async {
+    final res = await postgrest
+        .from('users')
+        .select('status')
+        .in_('status', ['ONLINE', 'OFFLINE']).execute();
+    res.data.forEach((item) {
+      expect(item['status'] == 'ONLINE' || item['status'] == 'OFFLINE', true);
+    });
+  });
+
+  test('contains', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .contains('age_range', '[1,2)')
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('containedBy', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .containedBy('age_range', '[1,2)')
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('rangeLt', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .rangeLt('age_range', '[2,25)')
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('rangeGt', () async {
+    final res = await postgrest
+        .from('users')
+        .select('age_range')
+        .rangeGt('age_range', '[2,25)')
+        .execute();
+    res.data.forEach((item) {
+      expect(item['username'] != 'supabot', true);
+    });
+  });
+
+  test('rangeGte', () async {
+    final res = await postgrest
+        .from('users')
+        .select('age_range')
+        .rangeGte('age_range', '[2,25)')
+        .execute();
+    res.data.forEach((item) {
+      expect(item['username'] != 'supabot', true);
+    });
+  });
+
+  test('rangeLte', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .rangeLte('age_range', '[2,25)')
+        .execute();
+    res.data.forEach((item) {
+      expect(item['username'] == 'supabot', true);
+    });
+  });
+
+  test('rangeAdjacent', () async {
+    final res = await postgrest
+        .from('users')
+        .select('age_range')
+        .rangeAdjacent('age_range', '[2,25)')
+        .execute();
+    expect(res.data.length, 3);
+  });
+
+  test('overlaps', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .overlaps('age_range', '[2,25)')
+        .execute();
+    expect(res.data[0]['username'], 'dragarcia');
+  });
+
+  test('textSearch', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch('catchphrase', "'fat' & 'cat'", config: 'english')
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('textSearch with plainto_tsquery', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch(
+          'catchphrase',
+          "'fat' & 'cat'",
+          config: 'english',
+          type: TextSearchType.plain,
+        )
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('textSearch with phraseto_tsquery', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch(
+          'catchphrase',
+          'cat',
+          config: 'english',
+          type: TextSearchType.phrase,
+        )
+        .execute();
+    expect(res.data.length, 2);
+  });
+
+  test('textSearch with websearch_to_tsquery', () async {
+    final res = await postgrest
+        .from('users')
+        .select('username')
+        .textSearch(
+          'catchphrase',
+          "'fat' & 'cat'",
+          config: 'english',
+          type: TextSearchType.websearch,
+        )
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('multiple filters', () async {
+    final res = await postgrest
+        .from('users')
+        .select()
+        .eq('username', 'supabot')
+        .is_('data', null)
+        .overlaps('age_range', '[1,2)')
+        .eq('status', 'ONLINE')
+        .textSearch('catchphrase', 'cat')
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('filter', () async {
+    final res = await postgrest
+        .from('users')
+        .select()
+        .filter('username', 'eq', 'supabot')
+        .execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('match', () async {
+    final res = await postgrest
+        .from('users')
+        .select()
+        .match({'username': 'supabot', 'status': 'ONLINE'}).execute();
+    expect(res.data[0]['username'], 'supabot');
+  });
+
+  test('filter on rpc', () async {
+    final res = await postgrest
+        .rpc('get_username_and_status', params: {'name_param': 'supabot'})
+        .neq('status', 'ONLINE')
+        .execute();
+    expect(res.data.isEmpty, true);
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently filters such as `eq` or `neq` are not supported on `rpc()` call within this package. If we take a look at `postgrest-js`, it is supported. 

This is because [`rpc()` on `postgrest-js`](https://github.com/supabase/postgrest-js/blob/master/src/lib/PostgrestRpcBuilder.ts#L34) returns `PostgrestFilterBuilder` where as `rpc()` on `postgrest-dart` returns `PostgrestTransformBuilder`, which does not have the methods for filters. 

## What is the current behavior?

`rpc()` returns `PostgrestTransformBuilder`, which does not have the methods for filters. 

## What is the new behavior?

`rpc()` returns `PostgrestFilterBuilder`, which does not have the methods for filters. 

## Additional context

I added one test that is the same as the one [found in `supabase-js`](https://github.com/supabase/postgrest-js/blob/master/test/filters.ts#L752). 

@phamhieu I was wondering if there was a specific reason why `rpc()` on `postgrest-dart` returns `PostgrestTransformBuilder` and not `PostgrestFilterBuilder` like `postgrest-js`, but do you have any additional context here?