### PR TITLE
feat: add hasError to PostgresResponse

### DIFF
--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 

--- a/lib/src/postgrest_response.dart
+++ b/lib/src/postgrest_response.dart
@@ -14,6 +14,8 @@ class PostgrestResponse {
   final PostgrestError? error;
   final int? count;
 
+  bool get hasError => error != null;
+
   factory PostgrestResponse.fromJson(Map<String, dynamic> json) =>
       PostgrestResponse(
         data: json['body'],

--- a/lib/src/postgrest_rpc_builder.dart
+++ b/lib/src/postgrest_rpc_builder.dart
@@ -1,5 +1,4 @@
 import 'package:postgrest/postgrest.dart';
-import 'postgrest_builder.dart';
 
 class PostgrestRpcBuilder extends PostgrestBuilder {
   PostgrestRpcBuilder(


### PR DESCRIPTION
## What kind of change does this PR introduce?

New feature.

## What is the current behavior?

To check whether a `PostgresResponse` has an error, you have to use `error != null`.

## What is the new behavior?

Now you can use `hasError`

## Additional context

Closes #35
