### PR TITLE
Fix/allow multiple filters on same column

### DIFF
--- a/infra/db/01-dummy-data.sql
+++ b/infra/db/01-dummy-data.sql
@@ -17,7 +17,7 @@ INSERT INTO
 VALUES
     ('Hello World 👋', 1, 'supabot', '2021-06-25T04:28:21.598Z'),
     ('Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.', 2, 'supabot', '2021-06-29T04:28:21.598Z'),
-    ('Supabase Launch Week is on fire', 3, 'supabot', '2021-06-20T04:28:21.598Z');
+    ('Supabase Launch Week is on fire', 1, 'supabot', '2021-06-20T04:28:21.598Z');
 
 INSERT INTO
     personal.users (username, status, age_range)

--- a/infra/db/01-dummy-data.sql
+++ b/infra/db/01-dummy-data.sql
@@ -16,7 +16,8 @@ INSERT INTO
     public.messages (message, channel_id, username, inserted_at)
 VALUES
     ('Hello World 👋', 1, 'supabot', '2021-06-25T04:28:21.598Z'),
-    ('Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.', 2, 'supabot', '2021-06-29T04:28:21.598Z');
+    ('Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.', 2, 'supabot', '2021-06-29T04:28:21.598Z'),
+    ('Supabase Launch Week is on fire', 3, 'supabot', '2021-06-20T04:28:21.598Z');
 
 INSERT INTO
     personal.users (username, status, age_range)

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -176,9 +176,10 @@ abstract class PostgrestBuilder {
   }
 
   /// Update Uri queryParameters with new key:value
+  /// Use lists to allow multiple values for the same key
   void appendSearchParams(String key, String value) {
-    final searchParams = Map<String, dynamic>.from(url.queryParameters);
-    searchParams[key] = value;
+    final searchParams = Map<String, dynamic>.from(url.queryParametersAll);
+    searchParams[key] = [...searchParams[key] ?? [], value];
     url = url.replace(queryParameters: searchParams);
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Column filters are sent as query parameters key. When adding a new filter, the current key gets overwritten. So you cannot apply multiple filters to the same column

## What is the new behavior?

The `Uri` class accepts a list as query parameter value to support multiple values for one key.

## Additional context
It's funny that @phamhieu added a new test today to check for date between two other dates, but I'm pretty sure if he had added another row with a date before the lower end, the test wouldn't pass. That's why I added a new row.