### PR TITLE
fix: added a tearDown in basic test to reset the table values after each test

### DIFF
--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -4,18 +4,18 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late Map<String, dynamic> users;
-  late Map<String, dynamic> channels;
-  late Map<String, dynamic> messages;
+  late List<Map<String, dynamic>> users;
+  late List<Map<String, dynamic>> channels;
+  late List<Map<String, dynamic>> messages;
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
     users = (await postgrest.from('users').select().execute()).data
-        as Map<String, dynamic>;
+        as List<Map<String, dynamic>>;
     channels = (await postgrest.from('channels').select().execute()).data
-        as Map<String, dynamic>;
+        as List<Map<String, dynamic>>;
     messages = (await postgrest.from('messages').select().execute()).data
-        as Map<String, dynamic>;
+        as List<Map<String, dynamic>>;
   });
 
   tearDown(() async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -4,9 +4,27 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
+  late Map<String, dynamic> users;
+  late Map<String, dynamic> channels;
+  late Map<String, dynamic> messages;
 
-  setUp(() {
+  setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
+    users = (await postgrest.from('users').select().execute()).data
+        as Map<String, dynamic>;
+    channels = (await postgrest.from('channels').select().execute()).data
+        as Map<String, dynamic>;
+    messages = (await postgrest.from('messages').select().execute()).data
+        as Map<String, dynamic>;
+  });
+
+  tearDown(() async {
+    await postgrest.from('users').delete().execute();
+    await postgrest.from('channels').delete().execute();
+    await postgrest.from('messages').delete().execute();
+    await postgrest.from('users').insert(users).execute();
+    await postgrest.from('channels').insert(channels).execute();
+    await postgrest.from('messages').insert(messages).execute();
   });
 
   test('basic select table', () async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -27,9 +27,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('users').delete().execute();
-    await postgrest.from('channels').delete().execute();
-    await postgrest.from('messages').delete().execute();
+    await postgrest.from('users').delete().neq('username', 'dne').execute();
+    await postgrest.from('channels').delete().neq('message', 'dne').execute();
+    await postgrest.from('messages').delete().neq('slug', 'dne').execute();
     final res = await postgrest.from('users').insert(users).execute();
     print(res.data);
     print(res.error.toString());

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -19,9 +19,6 @@ void main() {
     messages = List<Map<String, dynamic>>.from(
       (await postgrest.from('messages').select().execute()).data as List,
     );
-    print(users);
-    print(channels);
-    print(messages);
   });
 
   tearDown(() async {
@@ -92,6 +89,7 @@ void main() {
       {'username': 'dragarcia', 'status': 'OFFLINE'},
       onConflict: 'username',
     ).execute();
+    print(res.error.toString());
     expect(
       ((res.data as List)[0] as Map<String, dynamic>)['status'],
       'OFFLINE',

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -27,12 +27,12 @@ void main() {
   });
 
   tearDown(() async {
+    await postgrest.from('messages').delete().neq('slug', 'dne').execute();
+    await postgrest.from('channels').delete().neq('message', 'dne').execute();
     final deleteRes =
         await postgrest.from('users').delete().neq('username', 'dne').execute();
     print(deleteRes.data);
     print(deleteRes.error.toString());
-    await postgrest.from('channels').delete().neq('message', 'dne').execute();
-    await postgrest.from('messages').delete().neq('slug', 'dne').execute();
     final res = await postgrest.from('users').insert(users).execute();
     print(res.data);
     print(res.error.toString());

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -27,7 +27,10 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('users').delete().neq('username', 'dne').execute();
+    final deleteRes =
+        await postgrest.from('users').delete().neq('username', 'dne').execute();
+    print(deleteRes.data);
+    print(deleteRes.error.toString());
     await postgrest.from('channels').delete().neq('message', 'dne').execute();
     await postgrest.from('messages').delete().neq('slug', 'dne').execute();
     final res = await postgrest.from('users').insert(users).execute();

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -27,11 +27,14 @@ void main() {
   });
 
   tearDown(() async {
-    final messageDeleteRes =
-        await postgrest.from('messages').delete().neq('slug', 'dne').execute();
+    final messageDeleteRes = await postgrest
+        .from('messages')
+        .delete()
+        .neq('message', 'dne')
+        .execute();
     print(messageDeleteRes.data);
     print(messageDeleteRes.error.toString());
-    await postgrest.from('channels').delete().neq('message', 'dne').execute();
+    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
     final deleteRes =
         await postgrest.from('users').delete().neq('username', 'dne').execute();
     print(deleteRes.data);

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -19,6 +19,7 @@ void main() {
     messages = List<Map<String, dynamic>>.from(
       (await postgrest.from('messages').select().execute()).data as List,
     );
+    print(users);
   });
 
   setUp(() {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -30,7 +30,9 @@ void main() {
     await postgrest.from('users').delete().execute();
     await postgrest.from('channels').delete().execute();
     await postgrest.from('messages').delete().execute();
-    await postgrest.from('users').insert(users).execute();
+    final res = await postgrest.from('users').insert(users).execute();
+    print(res.data);
+    print(res.error.toString());
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();
     final resetUsers = List<Map<String, dynamic>>.from(

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -28,6 +28,10 @@ void main() {
     await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();
+    final resetUsers = List<Map<String, dynamic>>.from(
+      (await postgrest.from('users').select().execute()).data as List,
+    );
+    print(resetUsers);
   });
 
   test('basic select table', () async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -4,9 +4,9 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late List<Map<String, dynamic>> users;
-  late List<Map<String, dynamic>> channels;
-  late List<Map<String, dynamic>> messages;
+  late final List<Map<String, dynamic>> users;
+  late final List<Map<String, dynamic>> channels;
+  late final List<Map<String, dynamic>> messages;
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,25 +1,16 @@
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
+import 'reset_helper.dart';
+
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late final List<Map<String, dynamic>> users;
-  late final List<Map<String, dynamic>> channels;
-  late final List<Map<String, dynamic>> messages;
+  final resetHelper = ResetHelper();
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    users = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
-    );
-    channels = List<Map<String, dynamic>>.from(
-      (await postgrest.from('channels').select().execute()).data as List,
-    );
-    messages = List<Map<String, dynamic>>.from(
-      (await postgrest.from('messages').select().execute()).data as List,
-    );
-    print(users);
+    resetHelper.initialize();
   });
 
   setUp(() {
@@ -27,30 +18,7 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('messages').delete().neq('message', 'dne').execute();
-    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
-    await postgrest.from('users').delete().neq('username', 'dne').execute();
-    final usersInsertRes =
-        await postgrest.from('users').insert(users).execute();
-    final channelsInsertRes =
-        await postgrest.from('channels').insert(channels).execute();
-    final messagesInsertRes =
-        await postgrest.from('messages').insert(messages).execute();
-    if (usersInsertRes.hasError) {
-      fail(
-        'users table was not properly reset. ${usersInsertRes.error.toString()}',
-      );
-    }
-    if (channelsInsertRes.hasError) {
-      fail(
-        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
-      );
-    }
-    if (messagesInsertRes.hasError) {
-      fail(
-        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
-      );
-    }
+    resetHelper.reset();
   });
 
   test('basic select table', () async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -27,7 +27,10 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('messages').delete().neq('slug', 'dne').execute();
+    final messageDeleteRes =
+        await postgrest.from('messages').delete().neq('slug', 'dne').execute();
+    print(messageDeleteRes.data);
+    print(messageDeleteRes.error.toString());
     await postgrest.from('channels').delete().neq('message', 'dne').execute();
     final deleteRes =
         await postgrest.from('users').delete().neq('username', 'dne').execute();

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize();
+    resetHelper.initialize(postgrest);
   });
 
   setUp(() {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -27,27 +27,12 @@ void main() {
   });
 
   tearDown(() async {
-    final messageDeleteRes = await postgrest
-        .from('messages')
-        .delete()
-        .neq('message', 'dne')
-        .execute();
-    print(messageDeleteRes.data);
-    print(messageDeleteRes.error.toString());
+    await postgrest.from('messages').delete().neq('message', 'dne').execute();
     await postgrest.from('channels').delete().neq('slug', 'dne').execute();
-    final deleteRes =
-        await postgrest.from('users').delete().neq('username', 'dne').execute();
-    print(deleteRes.data);
-    print(deleteRes.error.toString());
-    final res = await postgrest.from('users').insert(users).execute();
-    print(res.data);
-    print(res.error.toString());
+    await postgrest.from('users').delete().neq('username', 'dne').execute();
+    await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();
-    final resetUsers = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
-    );
-    print(resetUsers);
   });
 
   test('basic select table', () async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -239,7 +239,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .update({'status': 'ONLINE'})
-        .eq('username', 'countexact')
+        .eq('username', 'kiwicopple')
         .execute(count: CountOption.exact);
     expect(res.count, 1);
   });
@@ -248,7 +248,7 @@ void main() {
     final res = await postgrest
         .from('users')
         .delete()
-        .eq('username', 'countexact')
+        .eq('username', 'kiwicopple')
         .execute(count: CountOption.exact);
 
     expect(res.count, 1);

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -21,6 +21,10 @@ void main() {
     );
   });
 
+  setUp(() {
+    postgrest = PostgrestClient(rootUrl);
+  });
+
   tearDown(() async {
     await postgrest.from('users').delete().execute();
     await postgrest.from('channels').delete().execute();
@@ -28,10 +32,6 @@ void main() {
     await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();
-    final resetUsers = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
-    );
-    print(resetUsers);
   });
 
   test('basic select table', () async {
@@ -93,7 +93,6 @@ void main() {
       {'username': 'dragarcia', 'status': 'OFFLINE'},
       onConflict: 'username',
     ).execute();
-    print(res.error.toString());
     expect(
       ((res.data as List)[0] as Map<String, dynamic>)['status'],
       'OFFLINE',

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -10,12 +10,15 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    users = (await postgrest.from('users').select().execute()).data
-        as List<Map<String, dynamic>>;
-    channels = (await postgrest.from('channels').select().execute()).data
-        as List<Map<String, dynamic>>;
-    messages = (await postgrest.from('messages').select().execute()).data
-        as List<Map<String, dynamic>>;
+    users = List<Map<String, dynamic>>.from(
+      (await postgrest.from('users').select().execute()).data as List,
+    );
+    channels = List<Map<String, dynamic>>.from(
+      (await postgrest.from('channels').select().execute()).data as List,
+    );
+    messages = List<Map<String, dynamic>>.from(
+      (await postgrest.from('messages').select().execute()).data as List,
+    );
   });
 
   tearDown(() async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -33,6 +33,10 @@ void main() {
     await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();
+    final resetUsers = List<Map<String, dynamic>>.from(
+      (await postgrest.from('users').select().execute()).data as List,
+    );
+    print(resetUsers);
   });
 
   test('basic select table', () async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -30,9 +30,27 @@ void main() {
     await postgrest.from('messages').delete().neq('message', 'dne').execute();
     await postgrest.from('channels').delete().neq('slug', 'dne').execute();
     await postgrest.from('users').delete().neq('username', 'dne').execute();
-    await postgrest.from('users').insert(users).execute();
-    await postgrest.from('channels').insert(channels).execute();
-    await postgrest.from('messages').insert(messages).execute();
+    final usersInsertRes =
+        await postgrest.from('users').insert(users).execute();
+    final channelsInsertRes =
+        await postgrest.from('channels').insert(channels).execute();
+    final messagesInsertRes =
+        await postgrest.from('messages').insert(messages).execute();
+    if (usersInsertRes.hasError) {
+      fail(
+        'users table was not properly reset. ${usersInsertRes.error.toString()}',
+      );
+    }
+    if (channelsInsertRes.hasError) {
+      fail(
+        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
+      );
+    }
+    if (messagesInsertRes.hasError) {
+      fail(
+        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
+      );
+    }
   });
 
   test('basic select table', () async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -19,6 +19,9 @@ void main() {
     messages = List<Map<String, dynamic>>.from(
       (await postgrest.from('messages').select().execute()).data as List,
     );
+    print(users);
+    print(channels);
+    print(messages);
   });
 
   tearDown(() async {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize(postgrest);
+    await resetHelper.initialize(postgrest);
   });
 
   setUp(() {
@@ -18,7 +18,7 @@ void main() {
   });
 
   tearDown(() async {
-    resetHelper.reset();
+    await resetHelper.reset();
   });
 
   test('basic select table', () async {

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -27,9 +27,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('users').delete().execute();
-    await postgrest.from('channels').delete().execute();
-    await postgrest.from('messages').delete().execute();
+    await postgrest.from('messages').delete().neq('message', 'dne').execute();
+    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
+    await postgrest.from('users').delete().neq('username', 'dne').execute();
     await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -4,9 +4,34 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
+  late List<Map<String, dynamic>> users;
+  late List<Map<String, dynamic>> channels;
+  late List<Map<String, dynamic>> messages;
+
+  setUpAll(() async {
+    postgrest = PostgrestClient(rootUrl);
+    users = List<Map<String, dynamic>>.from(
+      (await postgrest.from('users').select().execute()).data as List,
+    );
+    channels = List<Map<String, dynamic>>.from(
+      (await postgrest.from('channels').select().execute()).data as List,
+    );
+    messages = List<Map<String, dynamic>>.from(
+      (await postgrest.from('messages').select().execute()).data as List,
+    );
+  });
 
   setUp(() {
     postgrest = PostgrestClient(rootUrl);
+  });
+
+  tearDown(() async {
+    await postgrest.from('users').delete().execute();
+    await postgrest.from('channels').delete().execute();
+    await postgrest.from('messages').delete().execute();
+    await postgrest.from('users').insert(users).execute();
+    await postgrest.from('channels').insert(channels).execute();
+    await postgrest.from('messages').insert(messages).execute();
   });
 
   test('not', () async {

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -19,6 +19,7 @@ void main() {
     messages = List<Map<String, dynamic>>.from(
       (await postgrest.from('messages').select().execute()).data as List,
     );
+    print(users);
   });
 
   setUp(() {

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -30,11 +30,28 @@ void main() {
     await postgrest.from('messages').delete().neq('message', 'dne').execute();
     await postgrest.from('channels').delete().neq('slug', 'dne').execute();
     await postgrest.from('users').delete().neq('username', 'dne').execute();
-    await postgrest.from('users').insert(users).execute();
-    await postgrest.from('channels').insert(channels).execute();
-    await postgrest.from('messages').insert(messages).execute();
+    final usersInsertRes =
+        await postgrest.from('users').insert(users).execute();
+    final channelsInsertRes =
+        await postgrest.from('channels').insert(channels).execute();
+    final messagesInsertRes =
+        await postgrest.from('messages').insert(messages).execute();
+    if (usersInsertRes.hasError) {
+      fail(
+        'users table was not properly reset. ${usersInsertRes.error.toString()}',
+      );
+    }
+    if (channelsInsertRes.hasError) {
+      fail(
+        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
+      );
+    }
+    if (messagesInsertRes.hasError) {
+      fail(
+        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
+      );
+    }
   });
-
   test('not', () async {
     final res = await postgrest
         .from('users')

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -4,9 +4,9 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late List<Map<String, dynamic>> users;
-  late List<Map<String, dynamic>> channels;
-  late List<Map<String, dynamic>> messages;
+  late final List<Map<String, dynamic>> users;
+  late final List<Map<String, dynamic>> channels;
+  late final List<Map<String, dynamic>> messages;
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize();
+    resetHelper.initialize(postgrest);
   });
 
   setUp(() {

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -1,25 +1,16 @@
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
+import 'reset_helper.dart';
+
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late final List<Map<String, dynamic>> users;
-  late final List<Map<String, dynamic>> channels;
-  late final List<Map<String, dynamic>> messages;
+  final resetHelper = ResetHelper();
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    users = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
-    );
-    channels = List<Map<String, dynamic>>.from(
-      (await postgrest.from('channels').select().execute()).data as List,
-    );
-    messages = List<Map<String, dynamic>>.from(
-      (await postgrest.from('messages').select().execute()).data as List,
-    );
-    print(users);
+    resetHelper.initialize();
   });
 
   setUp(() {
@@ -27,31 +18,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('messages').delete().neq('message', 'dne').execute();
-    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
-    await postgrest.from('users').delete().neq('username', 'dne').execute();
-    final usersInsertRes =
-        await postgrest.from('users').insert(users).execute();
-    final channelsInsertRes =
-        await postgrest.from('channels').insert(channels).execute();
-    final messagesInsertRes =
-        await postgrest.from('messages').insert(messages).execute();
-    if (usersInsertRes.hasError) {
-      fail(
-        'users table was not properly reset. ${usersInsertRes.error.toString()}',
-      );
-    }
-    if (channelsInsertRes.hasError) {
-      fail(
-        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
-      );
-    }
-    if (messagesInsertRes.hasError) {
-      fail(
-        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
-      );
-    }
+    resetHelper.reset();
   });
+
   test('not', () async {
     final res = await postgrest
         .from('users')

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize(postgrest);
+    await resetHelper.initialize(postgrest);
   });
 
   setUp(() {
@@ -18,7 +18,7 @@ void main() {
   });
 
   tearDown(() async {
-    resetHelper.reset();
+    await resetHelper.reset();
   });
 
   test('not', () async {

--- a/test/reset_helper.dart
+++ b/test/reset_helper.dart
@@ -1,34 +1,35 @@
 import 'package:postgrest/postgrest.dart';
 
 class ResetHelper {
-  late final PostgrestClient postgrest;
+  late final PostgrestClient _postgrest;
 
   late final List<Map<String, dynamic>> _users;
   late final List<Map<String, dynamic>> _channels;
   late final List<Map<String, dynamic>> _messages;
 
-  Future<void> initialize() async {
+  Future<void> initialize(PostgrestClient postgrest) async {
+    _postgrest = postgrest;
     _users = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
+      (await _postgrest.from('users').select().execute()).data as List,
     );
     _channels = List<Map<String, dynamic>>.from(
-      (await postgrest.from('channels').select().execute()).data as List,
+      (await _postgrest.from('channels').select().execute()).data as List,
     );
     _messages = List<Map<String, dynamic>>.from(
-      (await postgrest.from('messages').select().execute()).data as List,
+      (await _postgrest.from('messages').select().execute()).data as List,
     );
   }
 
   Future<void> reset() async {
-    await postgrest.from('messages').delete().neq('message', 'dne').execute();
-    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
-    await postgrest.from('users').delete().neq('username', 'dne').execute();
+    await _postgrest.from('messages').delete().neq('message', 'dne').execute();
+    await _postgrest.from('channels').delete().neq('slug', 'dne').execute();
+    await _postgrest.from('users').delete().neq('username', 'dne').execute();
     final usersInsertRes =
-        await postgrest.from('users').insert(_users).execute();
+        await _postgrest.from('users').insert(_users).execute();
     final channelsInsertRes =
-        await postgrest.from('channels').insert(_channels).execute();
+        await _postgrest.from('channels').insert(_channels).execute();
     final messagesInsertRes =
-        await postgrest.from('messages').insert(_messages).execute();
+        await _postgrest.from('messages').insert(_messages).execute();
     if (usersInsertRes.hasError) {
       throw 'users table was not properly reset. ${usersInsertRes.error.toString()}';
     }

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -4,9 +4,34 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
+  late List<Map<String, dynamic>> users;
+  late List<Map<String, dynamic>> channels;
+  late List<Map<String, dynamic>> messages;
+
+  setUpAll(() async {
+    postgrest = PostgrestClient(rootUrl);
+    users = List<Map<String, dynamic>>.from(
+      (await postgrest.from('users').select().execute()).data as List,
+    );
+    channels = List<Map<String, dynamic>>.from(
+      (await postgrest.from('channels').select().execute()).data as List,
+    );
+    messages = List<Map<String, dynamic>>.from(
+      (await postgrest.from('messages').select().execute()).data as List,
+    );
+  });
 
   setUp(() {
     postgrest = PostgrestClient(rootUrl);
+  });
+
+  tearDown(() async {
+    await postgrest.from('users').delete().execute();
+    await postgrest.from('channels').delete().execute();
+    await postgrest.from('messages').delete().execute();
+    await postgrest.from('users').insert(users).execute();
+    await postgrest.from('channels').insert(channels).execute();
+    await postgrest.from('messages').insert(messages).execute();
   });
 
   test('embedded select', () async {

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -27,9 +27,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('users').delete().execute();
-    await postgrest.from('channels').delete().execute();
-    await postgrest.from('messages').delete().execute();
+    await postgrest.from('messages').delete().neq('message', 'dne').execute();
+    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
+    await postgrest.from('users').delete().neq('username', 'dne').execute();
     await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -19,6 +19,7 @@ void main() {
     messages = List<Map<String, dynamic>>.from(
       (await postgrest.from('messages').select().execute()).data as List,
     );
+    print(users);
   });
 
   setUp(() {

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -4,9 +4,9 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late List<Map<String, dynamic>> users;
-  late List<Map<String, dynamic>> channels;
-  late List<Map<String, dynamic>> messages;
+  late final List<Map<String, dynamic>> users;
+  late final List<Map<String, dynamic>> channels;
+  late final List<Map<String, dynamic>> messages;
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize();
+    resetHelper.initialize(postgrest);
   });
 
   setUp(() {

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -1,25 +1,16 @@
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
+import 'reset_helper.dart';
+
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late final List<Map<String, dynamic>> users;
-  late final List<Map<String, dynamic>> channels;
-  late final List<Map<String, dynamic>> messages;
+  final resetHelper = ResetHelper();
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    users = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
-    );
-    channels = List<Map<String, dynamic>>.from(
-      (await postgrest.from('channels').select().execute()).data as List,
-    );
-    messages = List<Map<String, dynamic>>.from(
-      (await postgrest.from('messages').select().execute()).data as List,
-    );
-    print(users);
+    resetHelper.initialize();
   });
 
   setUp(() {
@@ -27,31 +18,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('messages').delete().neq('message', 'dne').execute();
-    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
-    await postgrest.from('users').delete().neq('username', 'dne').execute();
-    final usersInsertRes =
-        await postgrest.from('users').insert(users).execute();
-    final channelsInsertRes =
-        await postgrest.from('channels').insert(channels).execute();
-    final messagesInsertRes =
-        await postgrest.from('messages').insert(messages).execute();
-    if (usersInsertRes.hasError) {
-      fail(
-        'users table was not properly reset. ${usersInsertRes.error.toString()}',
-      );
-    }
-    if (channelsInsertRes.hasError) {
-      fail(
-        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
-      );
-    }
-    if (messagesInsertRes.hasError) {
-      fail(
-        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
-      );
-    }
+    resetHelper.reset();
   });
+
   test('embedded select', () async {
     final res = await postgrest.from('users').select('messages(*)').execute();
     expect(

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -38,7 +38,7 @@ void main() {
     final res = await postgrest.from('users').select('messages(*)').execute();
     expect(
       (((res.data as List)[0] as Map)['messages'] as List).length,
-      2,
+      3,
     );
     expect(
       (((res.data as List)[1] as Map)['messages'] as List).length,
@@ -54,7 +54,7 @@ void main() {
         .execute();
     expect(
       (((res.data as List)[0] as Map)['messages'] as List).length,
-      1,
+      2,
     );
     expect(
       (((res.data as List)[1] as Map)['messages'] as List).length,
@@ -78,7 +78,7 @@ void main() {
         .execute();
     expect(
       (((res.data as List)[0] as Map)['messages'] as List).length,
-      2,
+      3,
     );
     expect(
       (((res.data as List)[1] as Map)['messages'] as List).length,
@@ -111,7 +111,7 @@ void main() {
     );
     expect(
       (((res.data as List)[3] as Map)['messages'] as List).length,
-      2,
+      3,
     );
     expect(
       ((((res.data as List)[3] as Map)['messages'] as List)[0] as Map)['id'],

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize(postgrest);
+    await resetHelper.initialize(postgrest);
   });
 
   setUp(() {
@@ -18,7 +18,7 @@ void main() {
   });
 
   tearDown(() async {
-    resetHelper.reset();
+    await resetHelper.reset();
   });
 
   test('embedded select', () async {

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -30,11 +30,28 @@ void main() {
     await postgrest.from('messages').delete().neq('message', 'dne').execute();
     await postgrest.from('channels').delete().neq('slug', 'dne').execute();
     await postgrest.from('users').delete().neq('username', 'dne').execute();
-    await postgrest.from('users').insert(users).execute();
-    await postgrest.from('channels').insert(channels).execute();
-    await postgrest.from('messages').insert(messages).execute();
+    final usersInsertRes =
+        await postgrest.from('users').insert(users).execute();
+    final channelsInsertRes =
+        await postgrest.from('channels').insert(channels).execute();
+    final messagesInsertRes =
+        await postgrest.from('messages').insert(messages).execute();
+    if (usersInsertRes.hasError) {
+      fail(
+        'users table was not properly reset. ${usersInsertRes.error.toString()}',
+      );
+    }
+    if (channelsInsertRes.hasError) {
+      fail(
+        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
+      );
+    }
+    if (messagesInsertRes.hasError) {
+      fail(
+        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
+      );
+    }
   });
-
   test('embedded select', () async {
     final res = await postgrest.from('users').select('messages(*)').execute();
     expect(

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -1,25 +1,16 @@
 import 'package:postgrest/postgrest.dart';
 import 'package:test/test.dart';
 
+import 'reset_helper.dart';
+
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late final List<Map<String, dynamic>> users;
-  late final List<Map<String, dynamic>> channels;
-  late final List<Map<String, dynamic>> messages;
+  final resetHelper = ResetHelper();
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    users = List<Map<String, dynamic>>.from(
-      (await postgrest.from('users').select().execute()).data as List,
-    );
-    channels = List<Map<String, dynamic>>.from(
-      (await postgrest.from('channels').select().execute()).data as List,
-    );
-    messages = List<Map<String, dynamic>>.from(
-      (await postgrest.from('messages').select().execute()).data as List,
-    );
-    print(users);
+    resetHelper.initialize();
   });
 
   setUp(() {
@@ -27,31 +18,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('messages').delete().neq('message', 'dne').execute();
-    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
-    await postgrest.from('users').delete().neq('username', 'dne').execute();
-    final usersInsertRes =
-        await postgrest.from('users').insert(users).execute();
-    final channelsInsertRes =
-        await postgrest.from('channels').insert(channels).execute();
-    final messagesInsertRes =
-        await postgrest.from('messages').insert(messages).execute();
-    if (usersInsertRes.hasError) {
-      fail(
-        'users table was not properly reset. ${usersInsertRes.error.toString()}',
-      );
-    }
-    if (channelsInsertRes.hasError) {
-      fail(
-        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
-      );
-    }
-    if (messagesInsertRes.hasError) {
-      fail(
-        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
-      );
-    }
+    resetHelper.reset();
   });
+
   test('order', () async {
     final res =
         await postgrest.from('users').select().order('username').execute();

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -4,9 +4,34 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
+  late List<Map<String, dynamic>> users;
+  late List<Map<String, dynamic>> channels;
+  late List<Map<String, dynamic>> messages;
+
+  setUpAll(() async {
+    postgrest = PostgrestClient(rootUrl);
+    users = List<Map<String, dynamic>>.from(
+      (await postgrest.from('users').select().execute()).data as List,
+    );
+    channels = List<Map<String, dynamic>>.from(
+      (await postgrest.from('channels').select().execute()).data as List,
+    );
+    messages = List<Map<String, dynamic>>.from(
+      (await postgrest.from('messages').select().execute()).data as List,
+    );
+  });
 
   setUp(() {
     postgrest = PostgrestClient(rootUrl);
+  });
+
+  tearDown(() async {
+    await postgrest.from('users').delete().execute();
+    await postgrest.from('channels').delete().execute();
+    await postgrest.from('messages').delete().execute();
+    await postgrest.from('users').insert(users).execute();
+    await postgrest.from('channels').insert(channels).execute();
+    await postgrest.from('messages').insert(messages).execute();
   });
 
   test('order', () async {

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -4,9 +4,9 @@ import 'package:test/test.dart';
 void main() {
   const rootUrl = 'http://localhost:3000';
   late PostgrestClient postgrest;
-  late List<Map<String, dynamic>> users;
-  late List<Map<String, dynamic>> channels;
-  late List<Map<String, dynamic>> messages;
+  late final List<Map<String, dynamic>> users;
+  late final List<Map<String, dynamic>> channels;
+  late final List<Map<String, dynamic>> messages;
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
@@ -51,6 +51,15 @@ void main() {
         .order('status', ascending: true)
         .order('username')
         .execute();
+    expect(
+      (res.data as List).map((row) => (row as Map)['status']),
+      [
+        'ONLINE',
+        'ONLINE',
+        'ONLINE',
+        'OFFLINE',
+      ],
+    );
     expect(
       (res.data as List).map((row) => (row as Map)['username']),
       [

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -27,9 +27,9 @@ void main() {
   });
 
   tearDown(() async {
-    await postgrest.from('users').delete().execute();
-    await postgrest.from('channels').delete().execute();
-    await postgrest.from('messages').delete().execute();
+    await postgrest.from('messages').delete().neq('message', 'dne').execute();
+    await postgrest.from('channels').delete().neq('slug', 'dne').execute();
+    await postgrest.from('users').delete().neq('username', 'dne').execute();
     await postgrest.from('users').insert(users).execute();
     await postgrest.from('channels').insert(channels).execute();
     await postgrest.from('messages').insert(messages).execute();

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -19,6 +19,7 @@ void main() {
     messages = List<Map<String, dynamic>>.from(
       (await postgrest.from('messages').select().execute()).data as List,
     );
+    print(users);
   });
 
   setUp(() {

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -30,11 +30,28 @@ void main() {
     await postgrest.from('messages').delete().neq('message', 'dne').execute();
     await postgrest.from('channels').delete().neq('slug', 'dne').execute();
     await postgrest.from('users').delete().neq('username', 'dne').execute();
-    await postgrest.from('users').insert(users).execute();
-    await postgrest.from('channels').insert(channels).execute();
-    await postgrest.from('messages').insert(messages).execute();
+    final usersInsertRes =
+        await postgrest.from('users').insert(users).execute();
+    final channelsInsertRes =
+        await postgrest.from('channels').insert(channels).execute();
+    final messagesInsertRes =
+        await postgrest.from('messages').insert(messages).execute();
+    if (usersInsertRes.hasError) {
+      fail(
+        'users table was not properly reset. ${usersInsertRes.error.toString()}',
+      );
+    }
+    if (channelsInsertRes.hasError) {
+      fail(
+        'channels table was not properly reset. ${channelsInsertRes.error.toString()}',
+      );
+    }
+    if (messagesInsertRes.hasError) {
+      fail(
+        'messages table was not properly reset. ${messagesInsertRes.error.toString()}',
+      );
+    }
   });
-
   test('order', () async {
     final res =
         await postgrest.from('users').select().order('username').execute();

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize();
+    resetHelper.initialize(postgrest);
   });
 
   setUp(() {

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   setUpAll(() async {
     postgrest = PostgrestClient(rootUrl);
-    resetHelper.initialize(postgrest);
+    await resetHelper.initialize(postgrest);
   });
 
   setUp(() {
@@ -18,7 +18,7 @@ void main() {
   });
 
   tearDown(() async {
-    resetHelper.reset();
+    await resetHelper.reset();
   });
 
   test('order', () async {

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -52,21 +52,12 @@ void main() {
         .order('username')
         .execute();
     expect(
-      (res.data as List).map((row) => (row as Map)['status']),
-      [
-        'ONLINE',
-        'ONLINE',
-        'OFFLINE',
-        'OFFLINE',
-      ],
-    );
-    expect(
       (res.data as List).map((row) => (row as Map)['username']),
       [
         'supabot',
+        'dragarcia',
         'awailas',
         'kiwicopple',
-        'dragarcia',
       ],
     );
   });


### PR DESCRIPTION
Currently, various test cases override the table values, and affects other tests. This PR aims to reset the value of test table after each test case executes for better testability. 