### PR TITLE
fix: bug where using multiple filters on the same field with order will wipe out the filters except the last one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.10+1]
+
+- fix: bug where using multiple filters on the same field with order will wipe out the filters except the last one. 
+
 ## [0.1.10]
 
 - feat: allow custom http client

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -232,7 +232,7 @@ class PostgrestBuilder<T> {
 
   /// Overrides Uri queryParameters with new key:value
   void overrideSearchParams(String key, String value) {
-    final searchParams = Map<String, dynamic>.from(url.queryParameters);
+    final searchParams = Map<String, dynamic>.from(url.queryParametersAll);
     searchParams[key] = value;
     url = url.replace(queryParameters: searchParams);
   }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.1.10';
+const version = '0.1.10+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 0.1.10
+version: 0.1.10+1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/postgrest-dart'
 

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -58,6 +58,23 @@ void main() {
     );
   });
 
+  test('order with filters on the same column', () async {
+    final res = await postgrest
+        .from('users')
+        .select()
+        .gt('username', 'b')
+        .lt('username', 'r')
+        .order('username')
+        .execute();
+    expect(
+      (res.data as List).map((row) => (row as Map)['username']),
+      [
+        'kiwicopple',
+        'dragarcia',
+      ],
+    );
+  });
+
   test('limit', () async {
     final res = await postgrest.from('users').select().limit(1).execute();
     expect((res.data as List).length, 1);


### PR DESCRIPTION
- Added tests to verify that multiple filters on the same filed with an order works properly
- Fixed a bug where using multiple filters on the same field with order will wipe out the filters except the last one