### PR TITLE
fix: add missing foreignTable arg to or filter

### DIFF
--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -46,8 +46,9 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().or('status.eq.OFFLINE,username.eq.supabot')
   /// ```
-  PostgrestFilterBuilder or(String filters) {
-    appendSearchParams('or', '($filters)');
+  PostgrestFilterBuilder or(String filters, {String? foreignTable}) {
+    final key = foreignTable != null ? '"$foreignTable".or' : 'or';
+    appendSearchParams(key, '($filters)');
     return this;
   }
 


### PR DESCRIPTION
Following the JavaScript client library feature set, the `foreignTable` parameter is missing on `or` https://supabase.com/docs/reference/javascript/or.

close https://github.com/supabase-community/supabase-flutter/issues/121