### PR TITLE
test: fix test

### DIFF
--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -338,13 +338,29 @@ class PostgrestBuilder<T> implements Future<T?> {
         }
       }
     } catch (error, stack) {
+      final dynamic result;
       if (onError != null) {
         if (onError is Function(Object, StackTrace)) {
-          onError(error, stack);
+          result = onError(error, stack);
         } else if (onError is Function(Object)) {
-          onError(error);
+          result = onError(error);
         } else {
-          rethrow;
+          throw ArgumentError.value(
+            onError,
+            "onError",
+            "Error handler must accept one Object or one Object and a StackTrace"
+                " as arguments, and return a value of the returned future's type",
+          );
+        }
+        // Give better error messages if the result is not a valid
+        // FutureOr<R>.
+        try {
+          return result;
+        } on TypeError {
+          throw ArgumentError(
+              "The error handler of Future.then"
+                  " must return a value of the returned future's type",
+              "onError");
         }
       }
       rethrow;

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -169,9 +169,9 @@ void main() {
       }
     });
 
-    test('connection error', () {
+    test('connection error', () async {
       final postgrest = PostgrestClient('http://this.url.does.not.exist');
-      postgrest.from('user').select().then(
+      postgrest.from('user').select().then<dynamic>(
         (value) {
           fail('Success on connection error');
         },

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -350,10 +350,21 @@ void main() {
       }
     });
     test('basic stored procedure call', () async {
-      final res = await postgrest.rpc('get_status', params: {
-        'name_param': 'supabot',
-      });
-      expect(res, 'ONLINE');
+      try {
+        await postgrestCustomHttpClient
+            .rpc('get_status', params: {'name_param': 'supabot'}).then(
+          (value) {
+            fail(
+                'Stored procedure was able to be called, even tho it does not exist');
+          },
+          onError: (error) {
+            expect(error, isA<PostgrestError>());
+            expect(error.code, '420');
+          },
+        );
+      } on PostgrestError catch (error) {
+        expect(error.code, '420');
+      }
     });
   });
 }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -155,7 +155,7 @@ void main() {
 
     test('missing table', () async {
       try {
-        await postgrest.from('missing_table').select().then(
+        await postgrest.from('missing_table').select().then<dynamic>(
           (value) {
             fail('found missing table');
           },
@@ -171,7 +171,7 @@ void main() {
 
     test('connection error', () async {
       final postgrest = PostgrestClient('http://this.url.does.not.exist');
-      postgrest.from('user').select().then<dynamic>(
+      await postgrest.from('user').select().then<dynamic>(
         (value) {
           fail('Success on connection error');
         },
@@ -302,7 +302,7 @@ void main() {
 
     test('row level security error', () async {
       try {
-        await postgrest.from('sample').update({'id': 2}).then(
+        await postgrest.from('sample').update({'id': 2}).then<dynamic>(
           (value) {
             fail('Returned even with row level security');
           },
@@ -336,7 +336,7 @@ void main() {
     });
     test('basic select table', () async {
       try {
-        await postgrestCustomHttpClient.from('users').select().then(
+        await postgrestCustomHttpClient.from('users').select().then<dynamic>(
           (value) {
             fail('Table was able to be selected, even tho it does not exist');
           },
@@ -352,7 +352,7 @@ void main() {
     test('basic stored procedure call', () async {
       try {
         await postgrestCustomHttpClient
-            .rpc('get_status', params: {'name_param': 'supabot'}).then(
+            .rpc('get_status', params: {'name_param': 'supabot'}).then<dynamic>(
           (value) {
             fail(
                 'Stored procedure was able to be called, even tho it does not exist');


### PR DESCRIPTION
Previous test didn't use the custom http client postgrest instance.
In addition, test were failing after pass, because `then` rethrew the error even if `onError` is given. I made now sure that the return type of `onValue` and `onError` is the same.