### PR TITLE
BREAKING: return minimal is enabled by default

### DIFF
--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -179,9 +179,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     return this;
   }
 
-  @Deprecated('Use `contains()` instead.')
-  PostgrestFilterBuilder Function(String, dynamic) get cs => contains;
-
   /// Finds all rows whose json, array, or range value on the stated [column] is contained by the specified [value].
   ///
   /// ```dart
@@ -202,9 +199,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     return this;
   }
 
-  @Deprecated('Use `containedBy()` instead.')
-  PostgrestFilterBuilder Function(String, dynamic) get cd => containedBy;
-
   /// Finds all rows whose range value on the stated [column] is strictly to the left of the specified [range].
   ///
   /// ```dart
@@ -214,9 +208,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     appendSearchParams(column, 'sl.$range');
     return this;
   }
-
-  @Deprecated('Use `rangeLt()` instead.')
-  PostgrestFilterBuilder Function(String, String) get sl => rangeLt;
 
   /// Finds all rows whose range value on the stated [column] is strictly to the right of the specified [range].
   ///
@@ -228,9 +219,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     return this;
   }
 
-  @Deprecated('Use `rangeGt()` instead.')
-  PostgrestFilterBuilder Function(String, String) get sr => rangeGt;
-
   /// Finds all rows whose range value on the stated [column] does not extend to the left of the specified [range].
   ///
   /// ```dart
@@ -240,9 +228,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     appendSearchParams(column, 'nxl.$range');
     return this;
   }
-
-  @Deprecated('Use `rangeGte()` instead.')
-  PostgrestFilterBuilder Function(String, String) get nxl => rangeGte;
 
   /// Finds all rows whose range value on the stated [column] does not extend to the right of the specified [range].
   ///
@@ -254,9 +239,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     return this;
   }
 
-  @Deprecated('Use `rangeLte()` instead.')
-  PostgrestFilterBuilder Function(String, String) get nxr => rangeLte;
-
   /// Finds all rows whose range value on the stated [column] is adjacent to the specified [range].
   ///
   /// ```dart
@@ -266,9 +248,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     appendSearchParams(column, 'adj.$range');
     return this;
   }
-
-  @Deprecated('Use `rangeAdjacent()` instead.')
-  PostgrestFilterBuilder Function(String, String) get adj => rangeAdjacent;
 
   /// Finds all rows whose array or range value on the stated [column] overlaps (has a value in common) with the specified [value].
   ///
@@ -286,9 +265,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     }
     return this;
   }
-
-  @Deprecated('Use `overlaps()` instead.')
-  PostgrestFilterBuilder Function(String, String) get ov => overlaps;
 
   /// Finds all rows whose text or tsvector value on the stated [column] matches the tsquery in [query].
   ///
@@ -315,58 +291,6 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
     }
     final configPart = config == null ? '' : '($config)';
     appendSearchParams(column, '${typePart}fts$configPart.$query');
-    return this;
-  }
-
-  /// Finds all rows whose tsvector value on the stated [column] matches to_tsquery([query]).
-  ///
-  /// [options] can contain `config` key which is text search configuration to use.
-  /// ```dart
-  /// postgrest.from('users').select().fts('catchphrase', "'fat' & 'cat'", config: 'english')
-  /// ```
-  @Deprecated('Use `textSearch()` instead.')
-  PostgrestFilterBuilder fts(String column, String query, {String? config}) {
-    final configPart = config == null ? '' : '($config)';
-    appendSearchParams(column, 'fts$configPart.$query');
-    return this;
-  }
-
-  /// Finds all rows whose tsvector value on the stated [column] matches plainto_tsquery([query]).
-  ///
-  /// [options] can contain `config` key which is text search configuration to use.
-  /// ```dart
-  /// postgrest.from('users').select().plfts('catchphrase', "'fat' & 'cat'", config: 'english')
-  /// ```
-  @Deprecated('Use `textSearch()` instead.')
-  PostgrestFilterBuilder plfts(String column, String query, {String? config}) {
-    final configPart = config == null ? '' : '($config)';
-    appendSearchParams(column, 'plfts$configPart.$query');
-    return this;
-  }
-
-  /// Finds all rows whose tsvector value on the stated [column] matches phraseto_tsquery([query]).
-  ///
-  /// [options] can contain `config` key which is text search configuration to use.
-  /// ```dart
-  /// postgrest.from('users').select().phfts('catchphrase', 'cat', config: 'english')
-  /// ```
-  @Deprecated('Use `textSearch()` instead.')
-  PostgrestFilterBuilder phfts(String column, String query, {String? config}) {
-    final configPart = config == null ? '' : '($config)';
-    appendSearchParams(column, 'phfts$configPart.$query');
-    return this;
-  }
-
-  /// Finds all rows whose tsvector value on the stated [column] matches websearch_to_tsquery([query]).
-  ///
-  /// [options] can contain `config` key which is text search configuration to use.
-  /// ```dart
-  /// postgrest.from('users').select().wfts('catchphrase', "'fat' & 'cat'", config: 'english')
-  /// ```
-  @Deprecated('Use `textSearch()` instead.')
-  PostgrestFilterBuilder wfts(String column, String query, {String? config}) {
-    final configPart = config == null ? '' : '($config)';
-    appendSearchParams(column, 'wfts$configPart.$query');
     return this;
   }
 

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -58,31 +58,15 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1})
   /// ```
-  PostgrestBuilder insert(
-    dynamic values, {
-    ReturningOption returning = ReturningOption.representation,
-    @Deprecated('Use `upsert()` method instead') bool upsert = false,
-    @Deprecated('Use `upsert()` method instead') String? onConflict,
-  }) {
+  PostgrestBuilder insert(dynamic values) {
     _method = METHOD_POST;
-    _headers['Prefer'] = upsert
-        ? 'return=${returning.name()},resolution=merge-duplicates'
-        : 'return=${returning.name()}';
-    if (onConflict != null) {
-      _url = _url.replace(
-        queryParameters: {
-          'on_conflict': onConflict,
-          ..._url.queryParameters,
-        },
-      );
-    }
+    _headers['Prefer'] = '';
     _body = values;
     return this;
   }
 
   /// Performs an UPSERT into the table.
   ///
-  /// By default the new record is returned. Set [returning] to minimal if you don't need this value.
   /// By specifying the [onConflict] query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
   /// [ignoreDuplicates] Specifies if duplicate rows should be ignored and not inserted.
   /// ```dart
@@ -90,14 +74,13 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```
   PostgrestBuilder upsert(
     dynamic values, {
-    ReturningOption returning = ReturningOption.representation,
     String? onConflict,
     bool ignoreDuplicates = false,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_POST;
     _headers['Prefer'] =
-        'return=${returning.name()},resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates';
+        'resolution=${ignoreDuplicates ? 'ignore' : 'merge'}-duplicates';
     if (onConflict != null) {
       _url = _url.replace(
         queryParameters: {
@@ -113,17 +96,15 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
 
   /// Performs an UPDATE on the table.
   ///
-  /// By default the updated record(s) will be returned. Set [returning] to minimal if you don't need this value.
   /// ```dart
   /// postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo')
   /// ```
   PostgrestFilterBuilder update(
     Map values, {
-    ReturningOption returning = ReturningOption.representation,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_PATCH;
-    _headers['Prefer'] = 'return=${returning.name()}';
+    _headers['Prefer'] = '';
     _body = values;
     _options = options.ensureNotHead();
     return PostgrestFilterBuilder(this);

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -58,11 +58,11 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1})
   /// ```
-  PostgrestBuilder insert(dynamic values) {
+  PostgrestFilterBuilder insert(dynamic values) {
     _method = METHOD_POST;
     _headers['Prefer'] = '';
     _body = values;
-    return this;
+    return PostgrestFilterBuilder(this);
   }
 
   /// Performs an UPSERT into the table.
@@ -72,7 +72,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').upsert({'id': 3, message: 'foo', 'username': 'supabot', 'channel_id': 2})
   /// ```
-  PostgrestBuilder upsert(
+  PostgrestFilterBuilder upsert(
     dynamic values, {
     String? onConflict,
     bool ignoreDuplicates = false,
@@ -91,7 +91,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     }
     _body = values;
     _options = options.ensureNotHead();
-    return this;
+    return PostgrestFilterBuilder(this);
   }
 
   /// Performs an UPDATE on the table.

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -32,6 +32,10 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
     }).join();
 
     appendSearchParams('select', cleanedColumns);
+    if (_headers['Prefer'] != null) {
+      _headers['Prefer'] = '${_headers['Prefer']},';
+    }
+    _headers['Prefer'] = '${_headers['Prefer']}return=representation';
     return this;
   }
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -97,8 +97,12 @@ void main() {
     });
 
     test('upsert', () async {
-      final List res = await postgrest.from('messages').upsert(
-          {'id': 3, 'message': 'foo', 'username': 'supabot', 'channel_id': 2});
+      final List res = await postgrest.from('messages').upsert({
+        'id': 3,
+        'message': 'foo',
+        'username': 'supabot',
+        'channel_id': 2
+      }).select();
       expect((res.first as Map)['id'], 3);
 
       final List resMsg = await postgrest.from('messages').select();
@@ -126,7 +130,33 @@ void main() {
       final res = await postgrest.from('messages').update(
         {'channel_id': 2},
       ).select();
-      expect(res, null);
+      expect(res, [
+        {
+          'id': 1,
+          'data': null,
+          'message': 'Hello World 👋',
+          'username': 'supabot',
+          'channel_id': 2,
+          'inserted_at': '2021-06-25T04:28:21.598+00:00'
+        },
+        {
+          'id': 2,
+          'data': null,
+          'message':
+              'Perfection is attained, not when there is nothing more to add, but when there is nothing left to take away.',
+          'username': 'supabot',
+          'channel_id': 2,
+          'inserted_at': '2021-06-29T04:28:21.598+00:00'
+        },
+        {
+          'id': 3,
+          'data': null,
+          'message': 'Supabase Launch Week is on fire',
+          'username': 'supabot',
+          'channel_id': 2,
+          'inserted_at': '2021-06-20T04:28:21.598+00:00'
+        }
+      ]);
 
       final Iterable<Map<String, dynamic>> messages = (await postgrest
               .from('messages')
@@ -144,7 +174,16 @@ void main() {
           .delete(returning: ReturningOption.minimal)
           .eq('message', 'Supabase Launch Week is on fire')
           .select();
-      expect(res, null);
+      expect(res, [
+        {
+          'id': 3,
+          'data': null,
+          'message': 'Supabase Launch Week is on fire',
+          'username': 'supabot',
+          'channel_id': 1,
+          'inserted_at': '2021-06-20T04:28:21.598+00:00'
+        }
+      ]);
 
       final List resMsg = await postgrest
           .from('messages')

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -125,7 +125,6 @@ void main() {
     test('basic update', () async {
       final res = await postgrest.from('messages').update(
         {'channel_id': 2},
-        returning: ReturningOption.minimal,
       );
       expect(res, null);
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -181,6 +181,11 @@ void main() {
       );
     });
 
+    test('Prefer: return=minimal', () async {
+      final data = await postgrest.from('users').insert({'username': 'bar'});
+      expect(data, null);
+    });
+
     test('select with head:true', () async {
       final res = await postgrest.from('users').select(
             '*',

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -89,7 +89,7 @@ void main() {
       final List res = await postgrest.from('users').upsert(
         {'username': 'dragarcia', 'status': 'OFFLINE'},
         onConflict: 'username',
-      );
+      ).select();
       expect(
         (res.first as Map<String, dynamic>)['status'],
         'OFFLINE',
@@ -110,7 +110,7 @@ void main() {
         {'username': 'dragarcia'},
         onConflict: 'username',
         ignoreDuplicates: true,
-      );
+      ).select();
       expect(res, isEmpty);
     });
 
@@ -118,14 +118,14 @@ void main() {
       final List res = await postgrest.from('messages').insert([
         {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
         {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1}
-      ]);
+      ]).select();
       expect(res.length, 2);
     });
 
     test('basic update', () async {
       final res = await postgrest.from('messages').update(
         {'channel_id': 2},
-      );
+      ).select();
       expect(res, null);
 
       final Iterable<Map<String, dynamic>> messages = (await postgrest
@@ -142,7 +142,8 @@ void main() {
       final res = await postgrest
           .from('messages')
           .delete(returning: ReturningOption.minimal)
-          .eq('message', 'Supabase Launch Week is on fire');
+          .eq('message', 'Supabase Launch Week is on fire')
+          .select();
       expect(res, null);
 
       final List resMsg = await postgrest
@@ -245,15 +246,19 @@ void main() {
         {'username': 'countexact', 'status': 'OFFLINE'},
         onConflict: 'username',
         options: FetchOptions(count: CountOption.exact),
-      );
+      ).select();
       expect(res.count, 1);
     });
 
     test('update with count: exact', () async {
-      final res = await postgrest.from('users').update(
-        {'status': 'ONLINE'},
-        options: FetchOptions(count: CountOption.exact),
-      ).eq('username', 'kiwicopple');
+      final res = await postgrest
+          .from('users')
+          .update(
+            {'status': 'ONLINE'},
+            options: FetchOptions(count: CountOption.exact),
+          )
+          .eq('username', 'kiwicopple')
+          .select();
       expect(res.count, 1);
     });
 
@@ -261,7 +266,8 @@ void main() {
       final res = await postgrest
           .from('users')
           .delete(options: FetchOptions(count: CountOption.exact))
-          .eq('username', 'kiwicopple');
+          .eq('username', 'kiwicopple')
+          .select();
 
       expect(res.count, 1);
     });
@@ -289,7 +295,7 @@ void main() {
     test('insert from uppercase table name', () async {
       final res = await postgrest.from('TestTable').insert([
         {'slug': 'new slug'}
-      ]);
+      ]).select();
       expect(
         (res.first as Map<String, dynamic>)['slug'],
         'new slug',
@@ -300,7 +306,8 @@ void main() {
       final res = await postgrest
           .from('TestTable')
           .delete(options: FetchOptions(count: CountOption.exact))
-          .eq('slug', 'new slug');
+          .eq('slug', 'new slug')
+          .select();
       expect(res.count, 1);
     });
 


### PR DESCRIPTION
With this update, the default behavior of performing `insert`, `update` or `upsert` is return minimul, and in order to return a value from those queries, you can add `select()` at the end like this.

```dart
final data = await Supabase.instance.client
  .from('my_table')
  .insert({'name': 'my_name'})
  .select();
```

This change was made to mirror the most recent API change in postgrest-js. 