### PR TITLE
Add returning option back to insert

### DIFF
--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -54,7 +54,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
 
   /// Performs an INSERT into the table.
   ///
-  /// By default no records are returned. Set [returning] to `representation` if you don't need this value.
+  /// By default no records are returned. Set [returning] to `representation` if you do need this value.
   ///
   /// Returns nothing (default):
   /// ```dart

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -54,12 +54,19 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
 
   /// Performs an INSERT into the table.
   ///
-  /// By default the new record is returned. Set [returning] to minimal if you don't need this value.
+  /// By default no records are returned. Set [returning] to `representation` if you don't need this value.
+  ///
+  /// Returns nothing (default):
   /// ```dart
   /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1})
   /// ```
+  /// Returns new entry:
+  /// ```dart
+  /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1}, returning: ReturningOption.representation)
+  /// ```
+
   PostgrestFilterBuilder insert(dynamic values,
-      {ReturningOption returning = ReturningOption.representation}) {
+      {ReturningOption returning = ReturningOption.minimal}) {
     _method = METHOD_POST;
     _headers['Prefer'] = 'return=${returning.name()}';
     _body = values;

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -58,9 +58,10 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1})
   /// ```
-  PostgrestFilterBuilder insert(dynamic values) {
+  PostgrestFilterBuilder insert(dynamic values,
+      {ReturningOption returning = ReturningOption.representation}) {
     _method = METHOD_POST;
-    _headers['Prefer'] = '';
+    _headers['Prefer'] = 'return=${returning.name()}';
     _body = values;
     return PostgrestFilterBuilder(this);
   }


### PR DESCRIPTION
The `returning` option on the `insert` method was excised in PR #80 . This adds that option back, sets it to the desired new default behavior `minimal` and updates the documentation to reflect that status. I added an example of overriding the behavior in the documentation as well.