### PR TITLE
feat: add generic types to `.select()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ import 'package:postgrest/postgrest.dart';
 
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
-final response = await client.from<PostgrestList>('users').select().withConverter((data) => data.map(User.fromJson).toList());
+final response = await client
+    .from('users')
+    .select<PostgrestList>()
+    .withConverter((data) => data.map(User.fromJson).toList());
 ```
 
 #### Insert records
@@ -43,7 +46,7 @@ import 'package:postgrest/postgrest.dart';
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
 try {
-  final data = await client.from('users')
+  await client.from('users')
     .insert([
       {'username': 'supabot', 'status': 'ONLINE'}
     ]);
@@ -63,7 +66,7 @@ import 'package:postgrest/postgrest.dart';
 
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
-final data = await client.from('users')
+await client.from('users')
       .update({'status': 'OFFLINE'})
       .eq('username', 'dragarcia');
 ```
@@ -75,7 +78,7 @@ import 'package:postgrest/postgrest.dart';
 
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
-final data = await client.from('users')
+await client.from('users')
       .delete()
       .eq('username', 'supabot');
 ```
@@ -87,8 +90,8 @@ import 'package:postgrest/postgrest.dart';
 
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
-final response = await client.from<PostgrestResponse>('countries')
-      .select('*', FetchOptions(count: CountOption.exact));
+final response = await client.from('countries')
+      .select<PostgrestResponse>('*', FetchOptions(count: CountOption.exact));
 final data = response.data;
 final count = response.count;
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,17 @@ import 'package:postgrest/postgrest.dart';
 
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
-final response = await client.from('users').select();
+final response = await client.from<PostgrestList>('users').select();
+```
+
+#### Reading your data and converting it to an object
+  
+```dart
+import 'package:postgrest/postgrest.dart';
+
+final url = 'https://example.com/postgrest/endpoint';
+final client = PostgrestClient(url);
+final response = await client.from<PostgrestList>('users').select().withConverter((data) => data.map(User.fromJson).toList());
 ```
 
 #### Insert records
@@ -77,7 +87,7 @@ import 'package:postgrest/postgrest.dart';
 
 final url = 'https://example.com/postgrest/endpoint';
 final client = PostgrestClient(url);
-final response = await client.from('countries')
+final response = await client.from<PostgrestResponse>('countries')
       .select('*', FetchOptions(count: CountOption.exact));
 final data = response.data;
 final count = response.count;

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -32,9 +32,9 @@ class PostgrestClient {
   }
 
   /// Perform a table operation.
-  PostgrestQueryBuilder from(String table) {
+  PostgrestQueryBuilder<T> from<T>(String table) {
     final url = '${this.url}/$table';
-    return PostgrestQueryBuilder(
+    return PostgrestQueryBuilder<T>(
       url,
       headers: headers,
       schema: schema,

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -32,8 +32,6 @@ class PostgrestClient {
   }
 
   /// Perform a table operation.
-  ///
-  /// [T] can only be [PostgrestList], [PostgrestMap], [PostgrestMap?], [PostgrestListResponse] or [PostgrestMapResponse]
   PostgrestQueryBuilder<void> from(String table) {
     final url = '${this.url}/$table';
     return PostgrestQueryBuilder<void>(

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -32,6 +32,8 @@ class PostgrestClient {
   }
 
   /// Perform a table operation.
+  ///
+  /// [T] can only be [PostgrestList], [PostgrestMap], [PostgrestMap?], [PostgrestListResponse] or [PostgrestMapResponse]
   PostgrestQueryBuilder<T> from<T>(String table) {
     final url = '${this.url}/$table';
     return PostgrestQueryBuilder<T>(

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -34,9 +34,9 @@ class PostgrestClient {
   /// Perform a table operation.
   ///
   /// [T] can only be [PostgrestList], [PostgrestMap], [PostgrestMap?], [PostgrestListResponse] or [PostgrestMapResponse]
-  PostgrestQueryBuilder<T> from<T>(String table) {
+  PostgrestQueryBuilder<void> from(String table) {
     final url = '${this.url}/$table';
-    return PostgrestQueryBuilder<T>(
+    return PostgrestQueryBuilder<void>(
       url,
       headers: headers,
       schema: schema,

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -83,6 +83,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
             R == (_Nullable<PostgrestMap>) ||
             R == PostgrestListResponse ||
             R == PostgrestMapResponse ||
+            R == (PostgrestResponse<PostgrestMap?>) ||
             R == PostgrestResponse ||
             R == List ||
             R == (List<Map>) ||
@@ -254,6 +255,20 @@ class PostgrestBuilder<T, S> implements Future<T> {
           body = _converter!(body as S);
         }
         return PostgrestResponse<PostgrestMap>(
+          data: body,
+          status: response.statusCode,
+          count: count,
+        );
+      } else if (S == PostgrestResponse<PostgrestMap?>) {
+        if (body == null) {
+          body = null;
+        } else {
+          body = PostgrestMap.from(body as Map);
+        }
+        if (_converter != null) {
+          body = _converter!(body as S);
+        }
+        return PostgrestResponse<PostgrestMap?>(
           data: body,
           status: response.statusCode,
           count: count,

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -85,6 +85,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
             R == PostgrestMapResponse ||
             R == PostgrestResponse ||
             R == List ||
+            R == (List<Map>) ||
             R == Map ||
             R == dynamic,
         "$R is not allowed as generic for `select<R>()`. Allowed types are: `PostgrestList`, `PostgrestMap`, `PostgrestMap?`, `PostgrestListResponse`, `PostgrestMapResponse`, `PostgrestResponse`, `dynamic`.");
@@ -225,6 +226,8 @@ class PostgrestBuilder<T, S> implements Future<T> {
       // When using converter [S] is the type of the converter functions's argument. Otherwise [T] should be equal to [S]
       if (S == PostgrestList) {
         body = PostgrestList.from(body as Iterable) as S;
+      } else if (S == List<Map>) {
+        body = List<Map>.from(body as Iterable) as S;
       } else if (S == PostgrestMap) {
         body = PostgrestMap.from(body as Map) as S;
 

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -24,7 +24,6 @@ const METHOD_PATCH = 'PATCH';
 const METHOD_DELETE = 'DELETE';
 
 typedef _Nullable<T> = T?;
-typedef _Void = void;
 
 /// The base builder class.
 class PostgrestBuilder<T, S> implements Future<T> {

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -24,6 +24,7 @@ const METHOD_PATCH = 'PATCH';
 const METHOD_DELETE = 'DELETE';
 
 typedef _Nullable<T> = T?;
+typedef _Void = void;
 
 /// The base builder class.
 class PostgrestBuilder<T, S> implements Future<T> {
@@ -74,6 +75,20 @@ class PostgrestBuilder<T, S> implements Future<T> {
     )
       .._maybeEmpty = _maybeEmpty
       .._converter = converter;
+  }
+
+  void _assertCorrectGeneric(Type R) {
+    assert(
+        R == PostgrestList ||
+            R == PostgrestMap ||
+            R == (_Nullable<PostgrestMap>) ||
+            R == PostgrestListResponse ||
+            R == PostgrestMapResponse ||
+            R == PostgrestResponse ||
+            R == List ||
+            R == Map ||
+            R == dynamic,
+        "$R is not allowed as generic for `select<R>()`. Allowed types are: `PostgrestList`, `PostgrestMap`, `PostgrestMap?`, `PostgrestListResponse`, `PostgrestMapResponse`, `PostgrestResponse`, `dynamic`.");
   }
 
   /// Sends the request and returns a [PostgrestResponse]

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -24,14 +24,14 @@ const METHOD_PATCH = 'PATCH';
 const METHOD_DELETE = 'DELETE';
 
 /// The base builder class.
-class PostgrestBuilder<T> implements Future<T?> {
+class PostgrestBuilder<T, S> implements Future<T> {
   dynamic _body;
   late final Headers _headers;
   bool _maybeEmpty = false;
   String? _method;
   late final String? _schema;
   late Uri _url;
-  PostgrestConverter? _converter;
+  PostgrestConverter<T, S>? _converter;
   late final Client? _httpClient;
   // ignore: prefer_final_fields
   FetchOptions? _options;
@@ -62,9 +62,8 @@ class PostgrestBuilder<T> implements Future<T?> {
   ///     .select()
   ///     .withConverter<User>((data) => User.fromJson(data));
   /// ```
-  PostgrestBuilder<S> withConverter<S>(PostgrestConverter<S> converter) {
-    _converter = converter;
-    return PostgrestBuilder<S>(
+  PostgrestBuilder<R, T> withConverter<R>(PostgrestConverter<R, T> converter) {
+    return PostgrestBuilder<R, T>(
       url: _url,
       headers: _headers,
       schema: _schema,
@@ -289,8 +288,8 @@ class PostgrestBuilder<T> implements Future<T?> {
   }
 
   @override
-  Stream<T?> asStream() {
-    final controller = StreamController<T?>.broadcast();
+  Stream<T> asStream() {
+    final controller = StreamController<T>.broadcast();
 
     then((value) {
       controller.add(value);
@@ -311,7 +310,7 @@ class PostgrestBuilder<T> implements Future<T?> {
   /// Register callbacks to be called when this future completes.
   @override
   Future<R> then<R>(
-    FutureOr<R> Function(T? value) onValue, {
+    FutureOr<R> Function(T value) onValue, {
     Function? onError,
   }) async {
     if (onError != null &&
@@ -378,7 +377,7 @@ class PostgrestBuilder<T> implements Future<T?> {
   }
 
   @override
-  Future<T?> whenComplete(FutureOr<void> Function() action) {
+  Future<T> whenComplete(FutureOr<void> Function() action) {
     return then(
       (v) {
         final f2 = action();

--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -1,7 +1,7 @@
 part of 'postgrest_builder.dart';
 
-class PostgrestFilterBuilder extends PostgrestTransformBuilder {
-  PostgrestFilterBuilder(PostgrestBuilder builder) : super(builder);
+class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
+  PostgrestFilterBuilder(PostgrestBuilder<T, T> builder) : super(builder);
 
   /// Convert list filter to query params string
   String _cleanFilterArray(List filter) {
@@ -17,7 +17,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().not('status', 'eq', 'OFFLINE')
   /// ```
-  PostgrestFilterBuilder not(String column, String operator, dynamic value) {
+  PostgrestFilterBuilder<T> not(String column, String operator, dynamic value) {
     if (value is List) {
       if (operator == "in") {
         appendSearchParams(
@@ -41,7 +41,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().or('status.eq.OFFLINE,username.eq.supabot')
   /// ```
-  PostgrestFilterBuilder or(String filters, {String? foreignTable}) {
+  PostgrestFilterBuilder<T> or(String filters, {String? foreignTable}) {
     final key = foreignTable != null ? '"$foreignTable".or' : 'or';
     appendSearchParams(key, '($filters)');
     return this;
@@ -52,7 +52,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().eq('username', 'supabot')
   /// ```
-  PostgrestFilterBuilder eq(String column, dynamic value) {
+  PostgrestFilterBuilder<T> eq(String column, dynamic value) {
     if (value is List) {
       appendSearchParams(column, 'eq.{${_cleanFilterArray(value)}}');
     } else {
@@ -66,7 +66,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().neq('username', 'supabot')
   /// ```
-  PostgrestFilterBuilder neq(String column, dynamic value) {
+  PostgrestFilterBuilder<T> neq(String column, dynamic value) {
     if (value is List) {
       appendSearchParams(column, 'neq.{${_cleanFilterArray(value)}}');
     } else {
@@ -80,7 +80,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('messages').select().gt('id', 1)
   /// ```
-  PostgrestFilterBuilder gt(String column, dynamic value) {
+  PostgrestFilterBuilder<T> gt(String column, dynamic value) {
     appendSearchParams(column, 'gt.$value');
     return this;
   }
@@ -90,7 +90,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('messages').select().gte('id', 1)
   /// ```
-  PostgrestFilterBuilder gte(String column, dynamic value) {
+  PostgrestFilterBuilder<T> gte(String column, dynamic value) {
     appendSearchParams(column, 'gte.$value');
     return this;
   }
@@ -100,7 +100,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('messages').select().lt('id', 2)
   /// ```
-  PostgrestFilterBuilder lt(String column, dynamic value) {
+  PostgrestFilterBuilder<T> lt(String column, dynamic value) {
     appendSearchParams(column, 'lt.$value');
     return this;
   }
@@ -110,7 +110,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('messages').select().lte('id', 2)
   /// ```
-  PostgrestFilterBuilder lte(String column, dynamic value) {
+  PostgrestFilterBuilder<T> lte(String column, dynamic value) {
     appendSearchParams(column, 'lte.$value');
     return this;
   }
@@ -120,7 +120,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().like('username', '%supa%')
   /// ```
-  PostgrestFilterBuilder like(String column, String pattern) {
+  PostgrestFilterBuilder<T> like(String column, String pattern) {
     appendSearchParams(column, 'like.$pattern');
     return this;
   }
@@ -130,7 +130,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().ilike('username', '%SUPA%')
   /// ```
-  PostgrestFilterBuilder ilike(String column, String pattern) {
+  PostgrestFilterBuilder<T> ilike(String column, String pattern) {
     appendSearchParams(column, 'ilike.$pattern');
     return this;
   }
@@ -142,7 +142,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// postgrest.from('users').select().is_('data', null)
   /// ```
   // ignore: non_constant_identifier_names
-  PostgrestFilterBuilder is_(String column, dynamic value) {
+  PostgrestFilterBuilder<T> is_(String column, dynamic value) {
     appendSearchParams(column, 'is.$value');
     return this;
   }
@@ -153,7 +153,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// postgrest.from('users').select().in_('status', ['ONLINE', 'OFFLINE'])
   /// ```
   // ignore: non_constant_identifier_names
-  PostgrestFilterBuilder in_(String column, List values) {
+  PostgrestFilterBuilder<T> in_(String column, List values) {
     appendSearchParams(column, 'in.(${_cleanFilterArray(values)})');
     return this;
   }
@@ -163,7 +163,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().contains('age_range', '[1,2)')
   /// ```
-  PostgrestFilterBuilder contains(String column, dynamic value) {
+  PostgrestFilterBuilder<T> contains(String column, dynamic value) {
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
@@ -183,7 +183,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().containedBy('age_range', '[1,2)')
   /// ```
-  PostgrestFilterBuilder containedBy(String column, dynamic value) {
+  PostgrestFilterBuilder<T> containedBy(String column, dynamic value) {
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
@@ -203,7 +203,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().sl('age_range', '[2,25)')
   /// ```
-  PostgrestFilterBuilder rangeLt(String column, String range) {
+  PostgrestFilterBuilder<T> rangeLt(String column, String range) {
     appendSearchParams(column, 'sl.$range');
     return this;
   }
@@ -213,7 +213,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().rangeGt('age_range', '[2,25)')
   /// ```
-  PostgrestFilterBuilder rangeGt(String column, String range) {
+  PostgrestFilterBuilder<T> rangeGt(String column, String range) {
     appendSearchParams(column, 'sr.$range');
     return this;
   }
@@ -223,7 +223,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().rangeGte('age_range', '[2,25)')
   /// ```
-  PostgrestFilterBuilder rangeGte(String column, String range) {
+  PostgrestFilterBuilder<T> rangeGte(String column, String range) {
     appendSearchParams(column, 'nxl.$range');
     return this;
   }
@@ -233,7 +233,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().rangeLte('age_range', '[2,25)')
   /// ```
-  PostgrestFilterBuilder rangeLte(String column, String range) {
+  PostgrestFilterBuilder<T> rangeLte(String column, String range) {
     appendSearchParams(column, 'nxr.$range');
     return this;
   }
@@ -243,7 +243,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().rangeAdjacent('age_range', '[2,25)')
   /// ```
-  PostgrestFilterBuilder rangeAdjacent(String column, String range) {
+  PostgrestFilterBuilder<T> rangeAdjacent(String column, String range) {
     appendSearchParams(column, 'adj.$range');
     return this;
   }
@@ -253,7 +253,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().overlaps('age_range', '[2,25)')
   /// ```
-  PostgrestFilterBuilder overlaps(String column, dynamic value) {
+  PostgrestFilterBuilder<T> overlaps(String column, dynamic value) {
     if (value is String) {
       // range types can be inclusive '[', ']' or exclusive '(', ')' so just
       // keep it simple and accept a string
@@ -270,7 +270,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().textSearch('catchphrase', "'fat' & 'cat'", config: 'english')
   /// ```
-  PostgrestFilterBuilder textSearch(
+  PostgrestFilterBuilder<T> textSearch(
     String column,
     String query, {
 
@@ -298,7 +298,8 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().filter('username', 'eq', 'supabot')
   /// ```
-  PostgrestFilterBuilder filter(String column, String operator, dynamic value) {
+  PostgrestFilterBuilder<T> filter(
+      String column, String operator, dynamic value) {
     if (value is List) {
       if (operator == "in") {
         appendSearchParams(
@@ -323,7 +324,7 @@ class PostgrestFilterBuilder extends PostgrestTransformBuilder {
   /// ```dart
   /// postgrest.from('users').select().match({'username': 'supabot', 'status': 'ONLINE'})
   /// ```
-  PostgrestFilterBuilder match(Map query) {
+  PostgrestFilterBuilder<T> match(Map query) {
     query.forEach((k, v) => appendSearchParams('$k', 'eq.$v'));
     return this;
   }

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -28,7 +28,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// ```dart
   /// postgrest.from('users').select('id, messages');
   /// ```
-  PostgrestFilterBuilder<T> select([
+  PostgrestFilterBuilder<R> select<R>([
     String columns = '*',
     FetchOptions options = const FetchOptions(),
   ]) {
@@ -49,7 +49,15 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
 
     appendSearchParams('select', cleanedColumns);
     _options = options;
-    return PostgrestFilterBuilder<T>(this);
+    return PostgrestFilterBuilder<R>(
+      PostgrestQueryBuilder(
+        _url.toString(),
+        headers: _headers,
+        schema: _schema,
+        httpClient: _httpClient,
+        options: _options,
+      ).._method = _method,
+    );
   }
 
   /// Performs an INSERT into the table.

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -8,7 +8,7 @@ part of 'postgrest_builder.dart';
 /// * update() - "patch"
 /// * delete() - "delete"
 /// Once any of these are called the filters are passed down to the Request.
-class PostgrestQueryBuilder extends PostgrestBuilder {
+class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   PostgrestQueryBuilder(
     String url, {
     Map<String, String>? headers,
@@ -28,7 +28,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('users').select('id, messages');
   /// ```
-  PostgrestFilterBuilder select([
+  PostgrestFilterBuilder<T> select([
     String columns = '*',
     FetchOptions options = const FetchOptions(),
   ]) {
@@ -49,7 +49,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
 
     appendSearchParams('select', cleanedColumns);
     _options = options;
-    return PostgrestFilterBuilder(this);
+    return PostgrestFilterBuilder<T>(this);
   }
 
   /// Performs an INSERT into the table.
@@ -65,11 +65,11 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1}).select()
   /// ```
-  PostgrestFilterBuilder insert(dynamic values) {
+  PostgrestFilterBuilder<T> insert(dynamic values) {
     _method = METHOD_POST;
     _headers['Prefer'] = '';
     _body = values;
-    return PostgrestFilterBuilder(this);
+    return PostgrestFilterBuilder<T>(this);
   }
 
   /// Performs an UPSERT into the table.
@@ -79,7 +79,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').upsert({'id': 3, message: 'foo', 'username': 'supabot', 'channel_id': 2})
   /// ```
-  PostgrestFilterBuilder upsert(
+  PostgrestFilterBuilder<T> upsert(
     dynamic values, {
     String? onConflict,
     bool ignoreDuplicates = false,
@@ -98,7 +98,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     }
     _body = values;
     _options = options.ensureNotHead();
-    return PostgrestFilterBuilder(this);
+    return PostgrestFilterBuilder<T>(this);
   }
 
   /// Performs an UPDATE on the table.
@@ -106,7 +106,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo')
   /// ```
-  PostgrestFilterBuilder update(
+  PostgrestFilterBuilder<T> update(
     Map values, {
     FetchOptions options = const FetchOptions(),
   }) {
@@ -114,7 +114,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
     _headers['Prefer'] = '';
     _body = values;
     _options = options.ensureNotHead();
-    return PostgrestFilterBuilder(this);
+    return PostgrestFilterBuilder<T>(this);
   }
 
   /// Performs a DELETE on the table.
@@ -123,13 +123,13 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
   /// ```dart
   /// postgrest.from('messages').delete().eq('message', 'foo')
   /// ```
-  PostgrestFilterBuilder delete({
+  PostgrestFilterBuilder<T> delete({
     ReturningOption returning = ReturningOption.representation,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_DELETE;
     _headers['Prefer'] = 'return=${returning.name()}';
     _options = options.ensureNotHead();
-    return PostgrestFilterBuilder(this);
+    return PostgrestFilterBuilder<T>(this);
   }
 }

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -32,7 +32,14 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// ```dart
   /// postgrest.from('users').select<PostgrestListResponse>('id, messages', FetchOptions(count: CountOption.exact));
   /// ```
-  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true`, the return type is `PostgrestResponse<T>`.
+  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true`, the return type is [PostgrestResponse<T>]. Otherwise it's `T` directly.
+  ///
+  /// The type specification for [R] is optional and enhances the type safety of the return value. But use with care as a wrong type specification will result in a runtime error.
+  ///
+  /// `T` is
+  /// - [List<Map<String, dynamic>>] for queries without `.single()` or `maybeSingle()`
+  /// - [Map<String, dynamic>] for queries with `.single()`
+  /// - [Map<String, dynamic>?] for queries with `.maybeSingle()`
   ///
   /// Allowed types for [R] are:
   /// - [List<Map<String, dynamic>>]
@@ -41,6 +48,9 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// - [PostgrestResponse<List<Map<String, dynamic>>>]
   /// - [PostgrestResponse<Map<String, dynamic>>]
   /// - [PostgrestResponse<Map<String, dynamic>?>]
+  /// - [PostgrestResponse]
+  ///
+  /// There are optional typedefs for [R]: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
   PostgrestFilterBuilder<R> select<R>([
     String columns = '*',
     FetchOptions options = const FetchOptions(),

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -29,13 +29,18 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// postgrest.from('users').select<PostgrestList>('id, messages');
   /// ```
   ///
+  /// ```dart
+  /// postgrest.from('users').select<PostgrestListResponse>('id, messages', FetchOptions(count: CountOption.exact));
+  /// ```
+  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true`, the return type is `PostgrestResponse<T>`.
+  ///
   /// Allowed types for [R] are:
-  /// - `PostgrestList`
-  /// - `PostgrestMap`
-  /// - `PostgrestMap?`
-  /// - `PostgrestListResponse`
-  /// - `PostgrestMapResponse`
-  /// - `PostgrestResponse`
+  /// - [PostgrestList]
+  /// - [PostgrestMap]
+  /// - [PostgrestMap?]
+  /// - [PostgrestListResponse]
+  /// - [PostgrestMapResponse]
+  /// - [PostgrestResponse]
   PostgrestFilterBuilder<R> select<R>([
     String columns = '*',
     FetchOptions options = const FetchOptions(),

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -35,12 +35,12 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true`, the return type is `PostgrestResponse<T>`.
   ///
   /// Allowed types for [R] are:
-  /// - [PostgrestList]
-  /// - [PostgrestMap]
-  /// - [PostgrestMap?]
-  /// - [PostgrestListResponse]
-  /// - [PostgrestMapResponse]
-  /// - [PostgrestResponse]
+  /// - [List<Map<String, dynamic>>]
+  /// - [Map<String, dynamic>]
+  /// - [Map<String, dynamic>?]
+  /// - [PostgrestResponse<List<Map<String, dynamic>>>]
+  /// - [PostgrestResponse<Map<String, dynamic>>]
+  /// - [PostgrestResponse<Map<String, dynamic>?>]
   PostgrestFilterBuilder<R> select<R>([
     String columns = '*',
     FetchOptions options = const FetchOptions(),

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -26,12 +26,21 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   /// Performs horizontal filtering with SELECT.
   ///
   /// ```dart
-  /// postgrest.from('users').select('id, messages');
+  /// postgrest.from('users').select<PostgrestList>('id, messages');
   /// ```
+  ///
+  /// Allowed types for [R] are:
+  /// - `PostgrestList`
+  /// - `PostgrestMap`
+  /// - `PostgrestMap?`
+  /// - `PostgrestListResponse`
+  /// - `PostgrestMapResponse`
+  /// - `PostgrestResponse`
   PostgrestFilterBuilder<R> select<R>([
     String columns = '*',
     FetchOptions options = const FetchOptions(),
   ]) {
+    _assertCorrectGeneric(R);
     _method = METHOD_GET;
 
     // Remove whitespaces except when quoted

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -1,7 +1,7 @@
 part of 'postgrest_builder.dart';
 
-class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
-  PostgrestTransformBuilder(PostgrestBuilder<T> builder)
+class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
+  PostgrestTransformBuilder(PostgrestBuilder<T, T> builder)
       : super(
           url: builder._url,
           method: builder._method,
@@ -17,7 +17,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /// ```dart
   /// postgrest.from('users').select('id, messages');
   /// ```
-  PostgrestTransformBuilder select([String columns = '*']) {
+  PostgrestTransformBuilder<T> select([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
     final re = RegExp(r'\s');
@@ -48,7 +48,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /// postgrest.from('users').select().order('username', ascending: false)
   /// postgrest.from('users').select('messages(*)').order('channel_id', foreignTable: 'messages', ascending: false)
   /// ```
-  PostgrestTransformBuilder order(
+  PostgrestTransformBuilder<T> order(
     String column, {
     bool ascending = false,
     bool nullsFirst = false,
@@ -70,7 +70,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /// postgrest.from('users').select().limit(1)
   /// postgrest.from('users').select('messages(*)').limit(1, foreignTable: 'messages')
   /// ```
-  PostgrestTransformBuilder limit(int count, {String? foreignTable}) {
+  PostgrestTransformBuilder<T> limit(int count, {String? foreignTable}) {
     final key = foreignTable == null ? 'limit' : '$foreignTable.limit';
 
     appendSearchParams(key, '$count');
@@ -83,7 +83,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /// ```dart
   /// postgrest.from('users').select('messages(*)').range(1, 1, foreignTable: 'messages')
   /// ```
-  PostgrestTransformBuilder range(int from, int to, {String? foreignTable}) {
+  PostgrestTransformBuilder<T> range(int from, int to, {String? foreignTable}) {
     final keyOffset = foreignTable == null ? 'offset' : '$foreignTable.offset';
     final keyLimit = foreignTable == null ? 'limit' : '$foreignTable.limit';
 
@@ -98,7 +98,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /// ```dart
   /// postgrest.from('users').select().limit(1).single()
   /// ```
-  PostgrestTransformBuilder single() {
+  PostgrestTransformBuilder<T> single() {
     _headers['Accept'] = 'application/vnd.pgrst.object+json';
     return this;
   }
@@ -107,7 +107,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   ///
   /// Result must be at most one row or nullable
   /// (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error.
-  PostgrestTransformBuilder maybeSingle() {
+  PostgrestTransformBuilder<T> maybeSingle() {
     _headers['Accept'] = 'application/vnd.pgrst.object+json';
     _maybeEmpty = true;
     return this;
@@ -119,7 +119,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
   /// ```dart
   /// postgrest.from('users').select().csv()
   /// ```
-  PostgrestTransformBuilder csv() {
+  PostgrestTransformBuilder<T> csv() {
     _headers['Accept'] = 'text/csv';
     return this;
   }

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -21,7 +21,14 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// postgrest.from('users').insert().select<PostgrestListResponse>('id, messages', FetchOptions(count: CountOption.exact));
   /// ```
   ///
-  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true` in `upsert`/`update`/`insert`/`delete`, the return type is `PostgrestResponse<T>`.
+  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true`, the return type is [PostgrestResponse<T>]. Otherwise it's `T` directly.
+  ///
+  /// The type specification for [R] is optional and enhances the type safety of the return value. But use with care as a wrong type specification will result in a runtime error.
+  ///
+  /// `T` is
+  /// - [List<Map<String, dynamic>>] for queries without `.single()` or `maybeSingle()`
+  /// - [Map<String, dynamic>] for queries with `.single()`
+  /// - [Map<String, dynamic>?] for queries with `.maybeSingle()`
   ///
   /// Allowed types for [R] are:
   /// - [List<Map<String, dynamic>>]
@@ -30,6 +37,9 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// - [PostgrestResponse<List<Map<String, dynamic>>>]
   /// - [PostgrestResponse<Map<String, dynamic>>]
   /// - [PostgrestResponse<Map<String, dynamic>?>]
+  /// - [PostgrestResponse]
+  ///
+  /// There are optional typedefs for [R]: [PostgrestMap], [PostgrestList], [PostgrestMapResponse], [PostgrestListResponse]
   PostgrestTransformBuilder<R> select<R>([String columns = '*']) {
     _assertCorrectGeneric(R);
     // Remove whitespaces except when quoted
@@ -123,9 +133,9 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// postgrest.from('users').select<PostgrestMap>().limit(1).single()
   /// ```
   ///
-  /// Return type is `PostgrestMap`(`Map<String, dynamic>`).
+  /// Data type is `Map<String, dynamic>`.
   ///
-  /// By specifying this type via `.select<PostgrestMap>()` you get more type safety.
+  /// By specifying this type via `.select<Map<String,dynamic>>()` you get more type safety.
   PostgrestTransformBuilder<T> single() {
     _headers['Accept'] = 'application/vnd.pgrst.object+json';
     return this;
@@ -137,9 +147,9 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error.
   ///
   ///
-  /// Return type is `PostgrestMap?`(`Map<String, dynamic>?`).
+  /// Data type is `Map<String, dynamic>?`.
   ///
-  /// By specifying this type via `.select<PostgrestMap?>()` you get more type safety.
+  /// By specifying this type via `.select<Map<String,dynamic>?>()` you get more type safety.
   PostgrestTransformBuilder<T> maybeSingle() {
     _headers['Accept'] = 'application/vnd.pgrst.object+json';
     _maybeEmpty = true;

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -17,7 +17,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// ```dart
   /// postgrest.from('users').select('id, messages');
   /// ```
-  PostgrestTransformBuilder<T> select([String columns = '*']) {
+  PostgrestTransformBuilder<R> select<R>([String columns = '*']) {
     // Remove whitespaces except when quoted
     var quoted = false;
     final re = RegExp(r'\s');
@@ -36,7 +36,17 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
       _headers['Prefer'] = '${_headers['Prefer']},';
     }
     _headers['Prefer'] = '${_headers['Prefer']}return=representation';
-    return this;
+    return PostgrestTransformBuilder<R>(
+      PostgrestBuilder(
+        headers: _headers,
+        url: _url,
+        httpClient: _httpClient,
+        options: _options,
+        body: _body,
+        method: _method,
+        schema: _schema,
+      ),
+    );
   }
 
   /// Orders the result with the specified [column].

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -24,12 +24,12 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true` in `upsert`/`update`/`insert`/`delete`, the return type is `PostgrestResponse<T>`.
   ///
   /// Allowed types for [R] are:
-  /// - [PostgrestList]
-  /// - [PostgrestMap]
-  /// - [PostgrestMap?]
-  /// - [PostgrestListResponse]
-  /// - [PostgrestMapResponse]
-  /// - [PostgrestResponse]
+  /// - [List<Map<String, dynamic>>]
+  /// - [Map<String, dynamic>]
+  /// - [Map<String, dynamic>?]
+  /// - [PostgrestResponse<List<Map<String, dynamic>>>]
+  /// - [PostgrestResponse<Map<String, dynamic>>]
+  /// - [PostgrestResponse<Map<String, dynamic>?>]
   PostgrestTransformBuilder<R> select<R>([String columns = '*']) {
     _assertCorrectGeneric(R);
     // Remove whitespaces except when quoted

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -17,7 +17,16 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// ```dart
   /// postgrest.from('users').select('id, messages');
   /// ```
+  ///
+  /// Allowed types for [R] are:
+  /// - `PostgrestList`
+  /// - `PostgrestMap`
+  /// - `PostgrestMap?`
+  /// - `PostgrestListResponse`
+  /// - `PostgrestMapResponse`
+  /// - `PostgrestResponse`
   PostgrestTransformBuilder<R> select<R>([String columns = '*']) {
+    _assertCorrectGeneric(R);
     // Remove whitespaces except when quoted
     var quoted = false;
     final re = RegExp(r'\s');

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -15,16 +15,21 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   /// Performs horizontal filtering with SELECT.
   ///
   /// ```dart
-  /// postgrest.from('users').select('id, messages');
+  /// postgrest.from('users').insert().select<PostgrestList>('id, messages');
+  /// ```
+  /// ```dart
+  /// postgrest.from('users').insert().select<PostgrestListResponse>('id, messages', FetchOptions(count: CountOption.exact));
   /// ```
   ///
+  /// By setting [FetchOptions.count] to non null or [FetchOptions.forceResponse] to `true` in `upsert`/`update`/`insert`/`delete`, the return type is `PostgrestResponse<T>`.
+  ///
   /// Allowed types for [R] are:
-  /// - `PostgrestList`
-  /// - `PostgrestMap`
-  /// - `PostgrestMap?`
-  /// - `PostgrestListResponse`
-  /// - `PostgrestMapResponse`
-  /// - `PostgrestResponse`
+  /// - [PostgrestList]
+  /// - [PostgrestMap]
+  /// - [PostgrestMap?]
+  /// - [PostgrestListResponse]
+  /// - [PostgrestMapResponse]
+  /// - [PostgrestResponse]
   PostgrestTransformBuilder<R> select<R>([String columns = '*']) {
     _assertCorrectGeneric(R);
     // Remove whitespaces except when quoted
@@ -115,8 +120,12 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// Result must be one row (e.g. using `limit`), otherwise this will result in an error.
   /// ```dart
-  /// postgrest.from('users').select().limit(1).single()
+  /// postgrest.from('users').select<PostgrestMap>().limit(1).single()
   /// ```
+  ///
+  /// Return type is `PostgrestMap`(`Map<String, dynamic>`).
+  ///
+  /// By specifying this type via `.select<PostgrestMap>()` you get more type safety.
   PostgrestTransformBuilder<T> single() {
     _headers['Accept'] = 'application/vnd.pgrst.object+json';
     return this;
@@ -126,6 +135,11 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// Result must be at most one row or nullable
   /// (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error.
+  ///
+  ///
+  /// Return type is `PostgrestMap?`(`Map<String, dynamic>?`).
+  ///
+  /// By specifying this type via `.select<PostgrestMap?>()` you get more type safety.
   PostgrestTransformBuilder<T> maybeSingle() {
     _headers['Accept'] = 'application/vnd.pgrst.object+json';
     _maybeEmpty = true;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,5 +1,5 @@
 typedef Headers = Map<String, String>;
-typedef PostgrestConverter<S> = S Function(dynamic data);
+typedef PostgrestConverter<S, T> = S Function(T data);
 
 /// A Postgrest response exception
 class PostgrestException implements Exception {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,7 +1,9 @@
 typedef Headers = Map<String, String>;
 typedef PostgrestConverter<S, T> = S Function(T data);
-typedef PostgrestList<T> = List<Map<String, T>>;
-typedef PostgrestListResponse<T> = PostgrestResponse<PostgrestList<T>>;
+typedef PostgrestList = List<PostgrestMap>;
+typedef PostgrestMap = Map<String, dynamic>;
+typedef PostgrestListResponse = PostgrestResponse<PostgrestList>;
+typedef PostgrestMapResponse = PostgrestResponse<PostgrestMap>;
 
 /// A Postgrest response exception
 class PostgrestException implements Exception {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,5 +1,7 @@
 typedef Headers = Map<String, String>;
 typedef PostgrestConverter<S, T> = S Function(T data);
+typedef PostgrestList<T> = List<Map<String, T>>;
+typedef PostgrestListResponse<T> = PostgrestResponse<PostgrestList<T>>;
 
 /// A Postgrest response exception
 class PostgrestException implements Exception {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -165,7 +165,7 @@ void main() {
       final Iterable<Map<String, dynamic>> messages = (await postgrest
               .from('messages')
               .select()
-              .withConverter<List>((data) => data as List))!
+              .withConverter<List>((data) => data as List))
           .cast<Map<String, dynamic>>();
       for (final rec in messages) {
         expect(rec['channel_id'], 2);

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -81,17 +81,17 @@ void main() {
 
     test('switch schema', () async {
       final postgrest = PostgrestClient(rootUrl, schema: 'personal');
-      final List res = await postgrest.from('users').select();
-      expect((res).length, 5);
+      final res = await postgrest.from('users').select<PostgrestList>();
+      expect(res.length, 5);
     });
 
     test('on_conflict upsert', () async {
-      final List res = await postgrest.from('users').upsert(
+      final res = await postgrest.from('users').upsert(
         {'username': 'dragarcia', 'status': 'OFFLINE'},
         onConflict: 'username',
-      ).select();
+      ).select<PostgrestList>();
       expect(
-        (res.first as Map<String, dynamic>)['status'],
+        res.first['status'],
         'OFFLINE',
       );
     });
@@ -103,7 +103,7 @@ void main() {
         'username': 'supabot',
         'channel_id': 2
       }).select<PostgrestList>();
-      expect((res.first)['id'], 3);
+      expect(res.first['id'], 3);
 
       final resMsg = await postgrest.from('messages').select<PostgrestList>();
       expect(resMsg.length, 3);
@@ -162,8 +162,7 @@ void main() {
         }
       ]);
 
-      final Iterable<Map<String, dynamic>> messages =
-          await postgrest.from('messages').select<PostgrestList>();
+      final messages = await postgrest.from('messages').select<PostgrestList>();
       for (final rec in messages) {
         expect(rec['channel_id'], 2);
       }

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -28,7 +28,7 @@ void main() {
     });
 
     test('basic select table', () async {
-      final res = await postgrest.from<PostgrestList>('users').select();
+      final res = await postgrest.from('users').select<PostgrestList>();
       expect(res.length, 4);
     });
 
@@ -97,43 +97,43 @@ void main() {
     });
 
     test('upsert', () async {
-      final res = await postgrest.from<PostgrestList>('messages').upsert({
+      final res = await postgrest.from('messages').upsert({
         'id': 3,
         'message': 'foo',
         'username': 'supabot',
         'channel_id': 2
-      }).select();
+      }).select<PostgrestList>();
       expect((res.first)['id'], 3);
 
-      final resMsg = await postgrest.from<PostgrestList>('messages').select();
+      final resMsg = await postgrest.from('messages').select<PostgrestList>();
       expect(resMsg.length, 3);
     });
 
     test('ignoreDuplicates upsert', () async {
-      final res = await postgrest.from<PostgrestList>('users').upsert(
+      final res = await postgrest.from('users').upsert(
         {'username': 'dragarcia'},
         onConflict: 'username',
         ignoreDuplicates: true,
-      ).select();
+      ).select<PostgrestList>();
       expect(res, isEmpty);
     });
 
     test('bulk insert', () async {
-      final res = await postgrest.from<PostgrestList>('messages').insert([
+      final res = await postgrest.from('messages').insert([
         {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
         {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1}
-      ]).select();
+      ]).select<PostgrestList>();
       expect(res.length, 2);
     });
 
     test('basic update', () async {
       final res = await postgrest
-          .from<PostgrestList>('messages')
+          .from('messages')
           .update(
             {'channel_id': 2},
           )
           .is_("data", null)
-          .select();
+          .select<PostgrestList>();
       expect(res, [
         {
           'id': 1,
@@ -163,7 +163,7 @@ void main() {
       ]);
 
       final Iterable<Map<String, dynamic>> messages =
-          await postgrest.from<PostgrestList>('messages').select();
+          await postgrest.from('messages').select<PostgrestList>();
       for (final rec in messages) {
         expect(rec['channel_id'], 2);
       }
@@ -171,10 +171,10 @@ void main() {
 
     test('basic delete', () async {
       final res = await postgrest
-          .from<PostgrestList>('messages')
+          .from('messages')
           .delete()
           .eq('message', 'Supabase Launch Week is on fire')
-          .select();
+          .select<PostgrestList>();
       expect(res, [
         {
           'id': 3,
@@ -187,8 +187,8 @@ void main() {
       ]);
 
       final resMsg = await postgrest
-          .from<PostgrestList>('messages')
-          .select()
+          .from('messages')
+          .select<PostgrestList>()
           .eq('message', 'Supabase Launch Week is on fire');
       expect(resMsg, isEmpty);
     });
@@ -196,8 +196,8 @@ void main() {
     test('missing table', () async {
       try {
         await postgrest
-            .from<PostgrestList>('missing_table')
-            .select()
+            .from('missing_table')
+            .select<PostgrestList>()
             .then<dynamic>(
           (value) {
             fail('found missing table');
@@ -225,8 +225,7 @@ void main() {
     });
 
     test('Prefer: return=minimal', () async {
-      final data = await postgrest.from('users').insert({'username': 'bar'});
-      expect(data, null);
+      await postgrest.from('users').insert({'username': 'bar'});
     });
 
     test('select with head:true', () async {
@@ -238,7 +237,7 @@ void main() {
     });
 
     test('select with head:true, count: exact', () async {
-      final res = await postgrest.from<PostgrestResponse>('users').select(
+      final res = await postgrest.from('users').select<PostgrestResponse>(
             '*',
             FetchOptions(head: true, count: CountOption.exact),
           );
@@ -248,16 +247,14 @@ void main() {
     });
 
     test('select with count: planned', () async {
-      final res = await postgrest
-          .from<PostgrestListResponse>('users')
-          .select('*', FetchOptions(count: CountOption.planned));
+      final res = await postgrest.from('users').select<PostgrestListResponse>(
+          '*', FetchOptions(count: CountOption.planned));
       expect(res.count, isNotNull);
     });
 
     test('select with head:true, count: estimated', () async {
-      final res = await postgrest
-          .from<PostgrestResponse>('users')
-          .select('*', FetchOptions(head: true, count: CountOption.estimated));
+      final res = await postgrest.from('users').select<PostgrestResponse>(
+          '*', FetchOptions(head: true, count: CountOption.estimated));
       expect(res.count, const TypeMatcher<int>());
     });
 
@@ -285,32 +282,32 @@ void main() {
     });
 
     test('insert with count: exact', () async {
-      final res = await postgrest.from<PostgrestListResponse>('users').upsert(
+      final res = await postgrest.from('users').upsert(
         {'username': 'countexact', 'status': 'OFFLINE'},
         onConflict: 'username',
         options: FetchOptions(count: CountOption.exact),
-      ).select();
+      ).select<PostgrestListResponse>();
       expect(res.count, 1);
     });
 
     test('update with count: exact', () async {
       final res = await postgrest
-          .from<PostgrestListResponse>('users')
+          .from('users')
           .update(
             {'status': 'ONLINE'},
             options: FetchOptions(count: CountOption.exact),
           )
           .eq('username', 'kiwicopple')
-          .select();
+          .select<PostgrestListResponse>();
       expect(res.count, 1);
     });
 
     test('delete with count: exact', () async {
       final res = await postgrest
-          .from<PostgrestListResponse>('users')
+          .from('users')
           .delete(options: FetchOptions(count: CountOption.exact))
           .eq('username', 'kiwicopple')
-          .select();
+          .select<PostgrestListResponse>();
 
       expect(res.count, 1);
     });
@@ -331,14 +328,14 @@ void main() {
     });
 
     test('select from uppercase table name', () async {
-      final res = await postgrest.from<PostgrestList>('TestTable').select();
+      final res = await postgrest.from('TestTable').select<PostgrestList>();
       expect(res.length, 2);
     });
 
     test('insert from uppercase table name', () async {
-      final res = await postgrest.from<PostgrestList>('TestTable').insert([
+      final res = await postgrest.from('TestTable').insert([
         {'slug': 'new slug'}
-      ]).select();
+      ]).select<PostgrestList>();
       expect(
         (res.first)['slug'],
         'new slug',
@@ -347,10 +344,10 @@ void main() {
 
     test('delete from uppercase table name', () async {
       final res = await postgrest
-          .from<PostgrestListResponse>('TestTable')
+          .from('TestTable')
           .delete(options: FetchOptions(count: CountOption.exact))
           .eq('slug', 'new slug')
-          .select();
+          .select<PostgrestListResponse>();
       expect(res.count, 1);
     });
 
@@ -372,8 +369,8 @@ void main() {
 
     test('withConverter', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select()
+          .from('users')
+          .select<PostgrestList>()
           .withConverter((data) => [data]);
       expect(res, isNotNull);
       expect(res, isNotEmpty);

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -28,7 +28,7 @@ void main() {
     });
 
     test('basic select table', () async {
-      final res = await postgrest.from<List>('users').select();
+      final res = await postgrest.from<PostgrestList>('users').select();
       expect(res.length, 4);
     });
 
@@ -97,7 +97,7 @@ void main() {
     });
 
     test('upsert', () async {
-      final res = await postgrest.from<List<Map>>('messages').upsert({
+      final res = await postgrest.from<PostgrestList>('messages').upsert({
         'id': 3,
         'message': 'foo',
         'username': 'supabot',
@@ -105,12 +105,12 @@ void main() {
       }).select();
       expect((res.first)['id'], 3);
 
-      final resMsg = await postgrest.from<List>('messages').select();
+      final resMsg = await postgrest.from<PostgrestList>('messages').select();
       expect(resMsg.length, 3);
     });
 
     test('ignoreDuplicates upsert', () async {
-      final res = await postgrest.from<List>('users').upsert(
+      final res = await postgrest.from<PostgrestList>('users').upsert(
         {'username': 'dragarcia'},
         onConflict: 'username',
         ignoreDuplicates: true,
@@ -119,7 +119,7 @@ void main() {
     });
 
     test('bulk insert', () async {
-      final res = await postgrest.from<List>('messages').insert([
+      final res = await postgrest.from<PostgrestList>('messages').insert([
         {'id': 4, 'message': 'foo', 'username': 'supabot', 'channel_id': 2},
         {'id': 5, 'message': 'foo', 'username': 'supabot', 'channel_id': 1}
       ]).select();
@@ -128,7 +128,7 @@ void main() {
 
     test('basic update', () async {
       final res = await postgrest
-          .from<List<Map>>('messages')
+          .from<PostgrestList>('messages')
           .update(
             {'channel_id': 2},
           )
@@ -162,11 +162,8 @@ void main() {
         }
       ]);
 
-      final Iterable<Map<String, dynamic>> messages = (await postgrest
-              .from<List>('messages')
-              .select()
-              .withConverter<List>((data) => data))
-          .cast<Map<String, dynamic>>();
+      final Iterable<Map<String, dynamic>> messages =
+          await postgrest.from<PostgrestList>('messages').select();
       for (final rec in messages) {
         expect(rec['channel_id'], 2);
       }
@@ -198,7 +195,10 @@ void main() {
 
     test('missing table', () async {
       try {
-        await postgrest.from<PostgrestList>('missing_table').select().then(
+        await postgrest
+            .from<PostgrestList>('missing_table')
+            .select()
+            .then<dynamic>(
           (value) {
             fail('found missing table');
           },
@@ -214,7 +214,7 @@ void main() {
 
     test('connection error', () async {
       final postgrest = PostgrestClient('http://this.url.does.not.exist');
-      await postgrest.from('user').select().then(
+      await postgrest.from('user').select().then<dynamic>(
         (value) {
           fail('Success on connection error');
         },
@@ -238,7 +238,7 @@ void main() {
     });
 
     test('select with head:true, count: exact', () async {
-      final res = await postgrest.from<PostgrestListResponse>('users').select(
+      final res = await postgrest.from<PostgrestResponse>('users').select(
             '*',
             FetchOptions(head: true, count: CountOption.exact),
           );
@@ -256,7 +256,7 @@ void main() {
 
     test('select with head:true, count: estimated', () async {
       final res = await postgrest
-          .from<PostgrestListResponse>('users')
+          .from<PostgrestResponse>('users')
           .select('*', FetchOptions(head: true, count: CountOption.estimated));
       expect(res.count, const TypeMatcher<int>());
     });
@@ -356,7 +356,7 @@ void main() {
 
     test('row level security error', () async {
       try {
-        await postgrest.from('sample').update({'id': 2}).then(
+        await postgrest.from('sample').update({'id': 2}).then<dynamic>(
           (value) {
             fail('Returned even with row level security');
           },
@@ -390,7 +390,7 @@ void main() {
     });
     test('basic select table', () async {
       try {
-        await postgrestCustomHttpClient.from('users').select().then(
+        await postgrestCustomHttpClient.from('users').select().then<dynamic>(
           (value) {
             fail('Table was able to be selected, even tho it does not exist');
           },

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -22,38 +22,38 @@ void main() {
   });
 
   test('not', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('status')
         .not('status', 'eq', 'OFFLINE');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item as Map)['status'] != ('OFFLINE'), true);
+      expect(item['status'] != ('OFFLINE'), true);
     }
   });
 
   test('not with in filter', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('username')
         .not('username', 'in', ['supabot', 'kiwicopple']);
     expect(res, isNotEmpty);
 
     for (final item in res) {
-      expect((item as Map)['username'] != ('supabot'), true);
+      expect(item['username'] != ('supabot'), true);
       expect(item['username'] != ('kiwicopple'), true);
     }
   });
 
   test('not with List of values', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('status')
         .not('interests', 'cs', ['baseball', 'basketball']);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
-        (((item as Map)['interests'] ?? []) as List)
+        ((item['interests'] ?? []) as List)
             .contains(['baseball', 'basketball']),
         false,
       );
@@ -61,16 +61,15 @@ void main() {
   });
 
   test('or', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('status, username')
         .or('status.eq.OFFLINE,username.eq.supabot');
     expect(res, isNotEmpty);
 
     for (final item in res) {
       expect(
-        (item as Map)['username'] == ('supabot') ||
-            item['status'] == ('OFFLINE'),
+        item['username'] == ('supabot') || item['status'] == ('OFFLINE'),
         true,
       );
     }
@@ -78,46 +77,46 @@ void main() {
 
   group("eq", () {
     test('eq string', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .eq('username', 'supabot');
       expect(res, isNotEmpty);
 
       for (final item in res) {
-        expect((item as Map)['username'] == ('supabot'), true);
+        expect(item['username'] == ('supabot'), true);
       }
     });
 
     test('eq list', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .eq('interests', ["basketball", "baseball"]);
       expect(res, isNotEmpty);
 
       for (final item in res) {
-        expect((item as Map)['username'] == ('supabot'), true);
+        expect(item['username'] == ('supabot'), true);
       }
     });
   });
 
   group("neq", () {
     test('neq string', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .neq('username', 'supabot');
       expect(res, isNotEmpty);
 
       for (final item in res) {
-        expect((item as Map)['username'] == ('supabot'), false);
+        expect(item['username'] == ('supabot'), false);
       }
     });
 
     test('neq list', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .neq('interests', ["football"]);
       expect(res, isNotEmpty);
@@ -128,275 +127,294 @@ void main() {
   });
 
   test('gt', () async {
-    final List res = await postgrest.from('messages').select('id').gt('id', 1);
+    final res = await postgrest
+        .from<PostgrestList>('messages')
+        .select('id')
+        .gt('id', 1);
     expect(res, isNotEmpty);
 
     for (final item in res) {
-      expect(((item as Map)['id'] as int) > 1, true);
+      expect((item['id'] as int) > 1, true);
     }
   });
 
   test('gte', () async {
-    final List res = await postgrest.from('messages').select('id').gte('id', 1);
+    final res = await postgrest
+        .from<PostgrestList>('messages')
+        .select('id')
+        .gte('id', 1);
     expect(res, isNotEmpty);
 
     for (final item in res) {
-      expect(((item as Map)['id'] as int) < 1, false);
+      expect((item['id'] as int) < 1, false);
     }
   });
 
   test('lt', () async {
-    final List res = await postgrest.from('messages').select('id').lt('id', 2);
+    final res = await postgrest
+        .from<PostgrestList>('messages')
+        .select('id')
+        .lt('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(((item as Map)['id'] as int) < 2, true);
+      expect((item['id'] as int) < 2, true);
     }
   });
 
   test('lte', () async {
-    final List res = await postgrest.from('messages').select('id').lte('id', 2);
+    final res = await postgrest
+        .from<PostgrestList>('messages')
+        .select('id')
+        .lte('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(((item as Map)['id'] as int) > 2, false);
+      expect((item['id'] as int) > 2, false);
     }
   });
 
   test('like', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('username')
         .like('username', '%supa%');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect(((item as Map)['username'] as String).contains('supa'), true);
+      expect((item['username'] as String).contains('supa'), true);
     }
   });
 
   test('ilike', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('username')
         .ilike('username', '%SUPA%');
     expect(res, isNotEmpty);
     for (final item in res) {
-      final user = ((item as Map)['username'] as String).toLowerCase();
+      final user = (item['username'] as String).toLowerCase();
       expect(user.contains('supa'), true);
     }
   });
 
   test('is', () async {
-    final List res =
-        await postgrest.from('users').select('data').is_('data', null);
+    final res = await postgrest
+        .from<PostgrestList>('users')
+        .select('data')
+        .is_('data', null);
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item as Map)['data'], null);
+      expect(item['data'], null);
     }
   });
 
   test('in', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('status')
         .in_('status', ['ONLINE', 'OFFLINE']);
     expect(res, isNotEmpty);
     for (final item in res) {
       expect(
-        (item as Map)['status'] == 'ONLINE' || item['status'] == 'OFFLINE',
+        item['status'] == 'ONLINE' || item['status'] == 'OFFLINE',
         true,
       );
     }
   });
   group("contains", () {
     test('contains range', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .contains('age_range', '[1,2)');
       expect(res, isNotEmpty);
       expect(
-        ((res)[0] as Map)['username'],
+        (res[0])['username'],
         'supabot',
       );
     });
 
     test('contains list', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .contains('interests', ["basketball", "baseball"]);
       expect(res, isNotEmpty);
       expect(
-        ((res)[0] as Map)['username'],
+        (res[0])['username'],
         'supabot',
       );
     });
   });
   group("containedBy", () {
     test('containedBy range', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .containedBy('age_range', '[0,3)');
       expect(res, isNotEmpty);
-      expect(((res)[0] as Map)['username'], 'supabot');
+      expect((res[0])['username'], 'supabot');
     });
 
     test('containedBy list', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .containedBy('interests', ["basketball", "baseball", "xxxx"]);
       expect(res, isNotEmpty);
-      expect(((res)[0] as Map)['username'], 'supabot');
+      expect(res[0]['username'], 'supabot');
     });
   });
 
   test('rangeLt', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('username')
         .rangeLt('age_range', '[2,25)');
     expect(res, isNotEmpty);
-    expect(((res)[0] as Map)['username'], 'supabot');
+    expect(res[0]['username'], 'supabot');
   });
 
   test('rangeGt', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('age_range')
         .rangeGt('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item as Map)['username'] != 'supabot', true);
+      expect(item['username'] != 'supabot', true);
     }
   });
 
   test('rangeGte', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('age_range')
         .rangeGte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item as Map)['username'] != 'supabot', true);
+      expect(item['username'] != 'supabot', true);
     }
   });
 
   test('rangeLte', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('username')
         .rangeLte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
-      expect((item as Map)['username'] == 'supabot', true);
+      expect(item['username'] == 'supabot', true);
     }
   });
 
   test('rangeAdjacent', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('age_range')
         .rangeAdjacent('age_range', '[2,25)');
-    expect((res).length, 3);
+    expect(res.length, 3);
   });
 
   group("overlap", () {
     test('overlaps range', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .overlaps('age_range', '[2,25)');
       expect(
-        ((res)[0] as Map)['username'],
+        (res[0])['username'],
         'dragarcia',
       );
     });
 
     test('overlaps list', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select('username')
           .overlaps('interests', ["basketball", "baseball"]);
       expect(
-        ((res)[0] as Map)['username'],
+        (res[0])['username'],
         'supabot',
       );
     });
   });
 
   test('textSearch', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select('username')
         .textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
-    expect(((res)[0] as Map)['username'], 'supabot');
+    expect(res[0]['username'], 'supabot');
   });
 
   test('textSearch with plainto_tsquery', () async {
-    final List res =
-        await postgrest.from('users').select('username').textSearch(
-              'catchphrase',
-              "'fat' & 'cat'",
-              config: 'english',
-              type: TextSearchType.plain,
-            );
-    expect(((res)[0] as Map)['username'], 'supabot');
+    final res = await postgrest
+        .from<PostgrestList>('users')
+        .select('username')
+        .textSearch(
+          'catchphrase',
+          "'fat' & 'cat'",
+          config: 'english',
+          type: TextSearchType.plain,
+        );
+    expect(res[0]['username'], 'supabot');
   });
 
   test('textSearch with phraseto_tsquery', () async {
-    final List res =
-        await postgrest.from('users').select('username').textSearch(
-              'catchphrase',
-              'cat',
-              config: 'english',
-              type: TextSearchType.phrase,
-            );
-    expect((res).length, 2);
+    final res = await postgrest
+        .from<PostgrestList>('users')
+        .select('username')
+        .textSearch(
+          'catchphrase',
+          'cat',
+          config: 'english',
+          type: TextSearchType.phrase,
+        );
+    expect(res.length, 2);
   });
 
   test('textSearch with websearch_to_tsquery', () async {
-    final List res =
-        await postgrest.from('users').select('username').textSearch(
-              'catchphrase',
-              "'fat' & 'cat'",
-              config: 'english',
-              type: TextSearchType.websearch,
-            );
-    expect(((res)[0] as Map)['username'], 'supabot');
+    final res = await postgrest
+        .from<PostgrestList>('users')
+        .select('username')
+        .textSearch(
+          'catchphrase',
+          "'fat' & 'cat'",
+          config: 'english',
+          type: TextSearchType.websearch,
+        );
+    expect(res[0]['username'], 'supabot');
   });
 
   test('multiple filters', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select()
         .eq('username', 'supabot')
         .is_('data', null)
         .overlaps('age_range', '[1,2)')
         .eq('status', 'ONLINE')
         .textSearch('catchphrase', 'cat');
-    expect(((res)[0] as Map)['username'], 'supabot');
+    expect(res[0]['username'], 'supabot');
   });
 
   group("filter", () {
     test('filter', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select()
           .filter('username', 'eq', 'supabot');
-      expect(((res)[0] as Map)['username'], 'supabot');
+      expect(res[0]['username'], 'supabot');
     });
 
     test('filter in with List of values', () async {
-      final List res = await postgrest
-          .from('users')
+      final res = await postgrest
+          .from<PostgrestList>('users')
           .select()
           .filter('username', 'in', ['supabot', 'kiwicopple']);
-      expect((res).length, 2);
+      expect(res.length, 2);
       for (final item in res) {
         expect(
-          (item as Map)['username'] == 'supabot' ||
-              item['username'] == 'kiwicopple',
+          item['username'] == 'supabot' || item['username'] == 'kiwicopple',
           true,
         );
       }
@@ -404,11 +422,11 @@ void main() {
   });
 
   test('match', () async {
-    final List res = await postgrest
-        .from('users')
+    final res = await postgrest
+        .from<PostgrestList>('users')
         .select()
         .match({'username': 'supabot', 'status': 'ONLINE'});
-    expect(((res)[0] as Map)['username'], 'supabot');
+    expect(res[0]['username'], 'supabot');
   });
 
   test('filter on rpc', () async {
@@ -418,20 +436,20 @@ void main() {
   });
 
   test('date range filter 1', () async {
-    final List res = await postgrest
-        .from('messages')
+    final res = await postgrest
+        .from<PostgrestList>('messages')
         .select()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-26').toIso8601String());
-    expect((res).length, 1);
+    expect(res.length, 1);
   });
 
   test('date range filter 2', () async {
-    final List res = await postgrest
-        .from('messages')
+    final res = await postgrest
+        .from<PostgrestList>('messages')
         .select()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-30').toIso8601String());
-    expect((res).length, 2);
+    expect(res.length, 2);
   });
 }

--- a/test/filter_test.dart
+++ b/test/filter_test.dart
@@ -23,8 +23,8 @@ void main() {
 
   test('not', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('status')
+        .from('users')
+        .select<PostgrestList>('status')
         .not('status', 'eq', 'OFFLINE');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -34,8 +34,8 @@ void main() {
 
   test('not with in filter', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .not('username', 'in', ['supabot', 'kiwicopple']);
     expect(res, isNotEmpty);
 
@@ -47,8 +47,8 @@ void main() {
 
   test('not with List of values', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('status')
+        .from('users')
+        .select<PostgrestList>('status')
         .not('interests', 'cs', ['baseball', 'basketball']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -62,8 +62,8 @@ void main() {
 
   test('or', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('status, username')
+        .from('users')
+        .select<PostgrestList>('status, username')
         .or('status.eq.OFFLINE,username.eq.supabot');
     expect(res, isNotEmpty);
 
@@ -78,8 +78,8 @@ void main() {
   group("eq", () {
     test('eq string', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .eq('username', 'supabot');
       expect(res, isNotEmpty);
 
@@ -90,8 +90,8 @@ void main() {
 
     test('eq list', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .eq('interests', ["basketball", "baseball"]);
       expect(res, isNotEmpty);
 
@@ -104,8 +104,8 @@ void main() {
   group("neq", () {
     test('neq string', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .neq('username', 'supabot');
       expect(res, isNotEmpty);
 
@@ -116,8 +116,8 @@ void main() {
 
     test('neq list', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .neq('interests', ["football"]);
       expect(res, isNotEmpty);
 
@@ -128,8 +128,8 @@ void main() {
 
   test('gt', () async {
     final res = await postgrest
-        .from<PostgrestList>('messages')
-        .select('id')
+        .from('messages')
+        .select<PostgrestList>('id')
         .gt('id', 1);
     expect(res, isNotEmpty);
 
@@ -140,8 +140,8 @@ void main() {
 
   test('gte', () async {
     final res = await postgrest
-        .from<PostgrestList>('messages')
-        .select('id')
+        .from('messages')
+        .select<PostgrestList>('id')
         .gte('id', 1);
     expect(res, isNotEmpty);
 
@@ -152,8 +152,8 @@ void main() {
 
   test('lt', () async {
     final res = await postgrest
-        .from<PostgrestList>('messages')
-        .select('id')
+        .from('messages')
+        .select<PostgrestList>('id')
         .lt('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -163,8 +163,8 @@ void main() {
 
   test('lte', () async {
     final res = await postgrest
-        .from<PostgrestList>('messages')
-        .select('id')
+        .from('messages')
+        .select<PostgrestList>('id')
         .lte('id', 2);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -174,8 +174,8 @@ void main() {
 
   test('like', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .like('username', '%supa%');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -185,8 +185,8 @@ void main() {
 
   test('ilike', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .ilike('username', '%SUPA%');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -197,8 +197,8 @@ void main() {
 
   test('is', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('data')
+        .from('users')
+        .select<PostgrestList>('data')
         .is_('data', null);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -208,8 +208,8 @@ void main() {
 
   test('in', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('status')
+        .from('users')
+        .select<PostgrestList>('status')
         .in_('status', ['ONLINE', 'OFFLINE']);
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -222,8 +222,8 @@ void main() {
   group("contains", () {
     test('contains range', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .contains('age_range', '[1,2)');
       expect(res, isNotEmpty);
       expect(
@@ -234,8 +234,8 @@ void main() {
 
     test('contains list', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .contains('interests', ["basketball", "baseball"]);
       expect(res, isNotEmpty);
       expect(
@@ -247,8 +247,8 @@ void main() {
   group("containedBy", () {
     test('containedBy range', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .containedBy('age_range', '[0,3)');
       expect(res, isNotEmpty);
       expect((res[0])['username'], 'supabot');
@@ -256,8 +256,8 @@ void main() {
 
     test('containedBy list', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .containedBy('interests', ["basketball", "baseball", "xxxx"]);
       expect(res, isNotEmpty);
       expect(res[0]['username'], 'supabot');
@@ -266,8 +266,8 @@ void main() {
 
   test('rangeLt', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .rangeLt('age_range', '[2,25)');
     expect(res, isNotEmpty);
     expect(res[0]['username'], 'supabot');
@@ -275,8 +275,8 @@ void main() {
 
   test('rangeGt', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('age_range')
+        .from('users')
+        .select<PostgrestList>('age_range')
         .rangeGt('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -286,8 +286,8 @@ void main() {
 
   test('rangeGte', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('age_range')
+        .from('users')
+        .select<PostgrestList>('age_range')
         .rangeGte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -297,8 +297,8 @@ void main() {
 
   test('rangeLte', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .rangeLte('age_range', '[2,25)');
     expect(res, isNotEmpty);
     for (final item in res) {
@@ -308,8 +308,8 @@ void main() {
 
   test('rangeAdjacent', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('age_range')
+        .from('users')
+        .select<PostgrestList>('age_range')
         .rangeAdjacent('age_range', '[2,25)');
     expect(res.length, 3);
   });
@@ -317,8 +317,8 @@ void main() {
   group("overlap", () {
     test('overlaps range', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .overlaps('age_range', '[2,25)');
       expect(
         (res[0])['username'],
@@ -328,8 +328,8 @@ void main() {
 
     test('overlaps list', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select('username')
+          .from('users')
+          .select<PostgrestList>('username')
           .overlaps('interests', ["basketball", "baseball"]);
       expect(
         (res[0])['username'],
@@ -340,16 +340,16 @@ void main() {
 
   test('textSearch', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
     expect(res[0]['username'], 'supabot');
   });
 
   test('textSearch with plainto_tsquery', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .textSearch(
           'catchphrase',
           "'fat' & 'cat'",
@@ -361,8 +361,8 @@ void main() {
 
   test('textSearch with phraseto_tsquery', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .textSearch(
           'catchphrase',
           'cat',
@@ -374,8 +374,8 @@ void main() {
 
   test('textSearch with websearch_to_tsquery', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username')
+        .from('users')
+        .select<PostgrestList>('username')
         .textSearch(
           'catchphrase',
           "'fat' & 'cat'",
@@ -387,8 +387,8 @@ void main() {
 
   test('multiple filters', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select()
+        .from('users')
+        .select<PostgrestList>()
         .eq('username', 'supabot')
         .is_('data', null)
         .overlaps('age_range', '[1,2)')
@@ -400,16 +400,16 @@ void main() {
   group("filter", () {
     test('filter', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select()
+          .from('users')
+          .select<PostgrestList>()
           .filter('username', 'eq', 'supabot');
       expect(res[0]['username'], 'supabot');
     });
 
     test('filter in with List of values', () async {
       final res = await postgrest
-          .from<PostgrestList>('users')
-          .select()
+          .from('users')
+          .select<PostgrestList>()
           .filter('username', 'in', ['supabot', 'kiwicopple']);
       expect(res.length, 2);
       for (final item in res) {
@@ -423,8 +423,8 @@ void main() {
 
   test('match', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select()
+        .from('users')
+        .select<PostgrestList>()
         .match({'username': 'supabot', 'status': 'ONLINE'});
     expect(res[0]['username'], 'supabot');
   });
@@ -437,8 +437,8 @@ void main() {
 
   test('date range filter 1', () async {
     final res = await postgrest
-        .from<PostgrestList>('messages')
-        .select()
+        .from('messages')
+        .select<PostgrestList>()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-26').toIso8601String());
     expect(res.length, 1);
@@ -446,8 +446,8 @@ void main() {
 
   test('date range filter 2', () async {
     final res = await postgrest
-        .from<PostgrestList>('messages')
-        .select()
+        .from('messages')
+        .select<PostgrestList>()
         .gte('inserted_at', DateTime.parse('2021-06-24').toIso8601String())
         .lte('inserted_at', DateTime.parse('2021-06-30').toIso8601String());
     expect(res.length, 2);

--- a/test/reset_helper.dart
+++ b/test/reset_helper.dart
@@ -10,10 +10,10 @@ class ResetHelper {
 
   Future<void> initialize(PostgrestClient postgrest) async {
     _postgrest = postgrest;
-    _users = (await _postgrest.from<PostgrestList>('users').select());
-    _channels = await _postgrest.from<PostgrestList>('channels').select();
-    _messages = await _postgrest.from<PostgrestList>('messages').select();
-    _reactions = await _postgrest.from<PostgrestList>('reactions').select();
+    _users = (await _postgrest.from('users').select<PostgrestList>());
+    _channels = await _postgrest.from('channels').select<PostgrestList>();
+    _messages = await _postgrest.from('messages').select<PostgrestList>();
+    _reactions = await _postgrest.from('reactions').select<PostgrestList>();
   }
 
   Future<void> reset() async {

--- a/test/reset_helper.dart
+++ b/test/reset_helper.dart
@@ -3,25 +3,17 @@ import 'package:postgrest/postgrest.dart';
 class ResetHelper {
   late final PostgrestClient _postgrest;
 
-  late final List<Map<String, dynamic>> _users;
-  late final List<Map<String, dynamic>> _channels;
-  late final List<Map<String, dynamic>> _messages;
-  late final List<Map<String, dynamic>> _reactions;
+  late final PostgrestList _users;
+  late final PostgrestList _channels;
+  late final PostgrestList _messages;
+  late final PostgrestList _reactions;
 
   Future<void> initialize(PostgrestClient postgrest) async {
     _postgrest = postgrest;
-    _users = List<Map<String, dynamic>>.from(
-      (await _postgrest.from('users').select()) as List,
-    );
-    _channels = List<Map<String, dynamic>>.from(
-      (await _postgrest.from('channels').select()) as List,
-    );
-    _messages = List<Map<String, dynamic>>.from(
-      (await _postgrest.from('messages').select()) as List,
-    );
-    _reactions = List<Map<String, dynamic>>.from(
-      (await _postgrest.from('reactions').select()) as List,
-    );
+    _users = (await _postgrest.from<PostgrestList>('users').select());
+    _channels = await _postgrest.from<PostgrestList>('channels').select();
+    _messages = await _postgrest.from<PostgrestList>('messages').select();
+    _reactions = await _postgrest.from<PostgrestList>('reactions').select();
   }
 
   Future<void> reset() async {

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -22,129 +22,131 @@ void main() {
   });
 
   test('embedded select', () async {
-    final res = await postgrest.from('users').select('messages(*)');
+    final res = await postgrest
+        .from<PostgrestList<List>>('users')
+        .select('messages(*)');
     expect(
-      (((res as List)[0] as Map)['messages'] as List).length,
+      res[0]['messages']!.length,
       3,
     );
     expect(
-      (((res)[1] as Map)['messages'] as List).length,
+      res[1]['messages']!.length,
       0,
     );
   });
 
   test('embedded eq', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList<List>>('users')
         .select('messages(*)')
         .eq('messages.channel_id', 1);
     expect(
-      (((res as List)[0] as Map)['messages'] as List).length,
+      res[0]['messages']!.length,
       2,
     );
     expect(
-      (((res)[1] as Map)['messages'] as List).length,
+      res[1]['messages']!.length,
       0,
     );
     expect(
-      (((res)[2] as Map)['messages'] as List).length,
+      res[2]['messages']!.length,
       0,
     );
     expect(
-      (((res)[3] as Map)['messages'] as List).length,
+      res[3]['messages']!.length,
       0,
     );
   });
 
   test('embedded order', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList<List<Map>>>('users')
         .select('messages(*)')
         .order('channel_id', foreignTable: 'messages');
     expect(
-      (((res as List)[0] as Map)['messages'] as List).length,
+      res[0]['messages']!.length,
       3,
     );
     expect(
-      (((res)[1] as Map)['messages'] as List).length,
+      res[1]['messages']!.length,
       0,
     );
     expect(
-      ((((res)[0] as Map)['messages'] as List)[0] as Map)['id'],
+      res[0]['messages']![0]['id'],
       2,
     );
   });
 
   test('embedded order on multiple columns', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList>('users')
         .select('username, messages(*)')
         .order('username', ascending: true)
         .order('channel_id', foreignTable: 'messages');
     expect(
-      ((res as List)[0] as Map)['username'],
+      res[0]['username'],
       'awailas',
     );
     expect(
-      ((res)[3] as Map)['username'],
+      res[3]['username'],
       'supabot',
     );
     expect(
-      (((res)[0] as Map)['messages'] as List).length,
+      (res[0]['messages'] as List).length,
       0,
     );
     expect(
-      (((res)[3] as Map)['messages'] as List).length,
+      (res[3]['messages'] as List).length,
       3,
     );
     expect(
-      ((((res)[3] as Map)['messages'] as List)[0] as Map)['id'],
+      (res[3]['messages'] as List<Map>)[0]['id'],
       2,
     );
   });
 
   test('embedded limit', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList<List>>('users')
         .select('messages(*)')
         .limit(1, foreignTable: 'messages');
     expect(
-      (((res as List)[0] as Map)['messages'] as List).length,
+      res[0]['messages']!.length,
       1,
     );
     expect(
-      (((res)[1] as Map)['messages'] as List).length,
+      res[1]['messages']!.length,
       0,
     );
     expect(
-      (((res)[2] as Map)['messages'] as List).length,
+      res[2]['messages']!.length,
       0,
     );
     expect(
-      (((res)[3] as Map)['messages'] as List).length,
+      res[3]['messages']!.length,
       0,
     );
   });
 
   test('embedded range', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList>('users')
         .select('messages(*)')
         .range(1, 1, foreignTable: 'messages');
     expect(
-      (((res as List)[0] as Map)['messages'] as List).length,
+      res[0]['messages']!.length,
       1,
     );
     expect(
-      (((res)[1] as Map)['messages'] as List).length,
+      res[1]['messages']!.length,
       0,
     );
     expect(
-      (((res)[2] as Map)['messages'] as List).length,
+      res[2]['messages']!.length,
       0,
     );
     expect(
-      (((res)[3] as Map)['messages'] as List).length,
+      res[3]['messages']!.length,
       0,
     );
   });

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -22,9 +22,8 @@ void main() {
   });
 
   test('embedded select', () async {
-    final res = await postgrest
-        .from<PostgrestList<List>>('users')
-        .select('messages(*)');
+    final res =
+        await postgrest.from<PostgrestList>('users').select('messages(*)');
     expect(
       res[0]['messages']!.length,
       3,
@@ -37,7 +36,7 @@ void main() {
 
   test('embedded eq', () async {
     final res = await postgrest
-        .from<PostgrestList<List>>('users')
+        .from<PostgrestList>('users')
         .select('messages(*)')
         .eq('messages.channel_id', 1);
     expect(
@@ -60,7 +59,7 @@ void main() {
 
   test('embedded order', () async {
     final res = await postgrest
-        .from<PostgrestList<List<Map>>>('users')
+        .from<PostgrestList>('users')
         .select('messages(*)')
         .order('channel_id', foreignTable: 'messages');
     expect(
@@ -100,14 +99,14 @@ void main() {
       3,
     );
     expect(
-      (res[3]['messages'] as List<Map>)[0]['id'],
+      (res[3]['messages'] as List)[0]['id'],
       2,
     );
   });
 
   test('embedded limit', () async {
     final res = await postgrest
-        .from<PostgrestList<List>>('users')
+        .from<PostgrestList>('users')
         .select('messages(*)')
         .limit(1, foreignTable: 'messages');
     expect(

--- a/test/resource_embedding_test.dart
+++ b/test/resource_embedding_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   test('embedded select', () async {
     final res =
-        await postgrest.from<PostgrestList>('users').select('messages(*)');
+        await postgrest.from('users').select<PostgrestList>('messages(*)');
     expect(
       res[0]['messages']!.length,
       3,
@@ -36,8 +36,8 @@ void main() {
 
   test('embedded eq', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('messages(*)')
+        .from('users')
+        .select<PostgrestList>('messages(*)')
         .eq('messages.channel_id', 1);
     expect(
       res[0]['messages']!.length,
@@ -59,8 +59,8 @@ void main() {
 
   test('embedded order', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('messages(*)')
+        .from('users')
+        .select<PostgrestList>('messages(*)')
         .order('channel_id', foreignTable: 'messages');
     expect(
       res[0]['messages']!.length,
@@ -78,8 +78,8 @@ void main() {
 
   test('embedded order on multiple columns', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('username, messages(*)')
+        .from('users')
+        .select<PostgrestList>('username, messages(*)')
         .order('username', ascending: true)
         .order('channel_id', foreignTable: 'messages');
     expect(
@@ -106,8 +106,8 @@ void main() {
 
   test('embedded limit', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('messages(*)')
+        .from('users')
+        .select<PostgrestList>('messages(*)')
         .limit(1, foreignTable: 'messages');
     expect(
       res[0]['messages']!.length,
@@ -129,8 +129,8 @@ void main() {
 
   test('embedded range', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select('messages(*)')
+        .from('users')
+        .select<PostgrestList>('messages(*)')
         .range(1, 1, foreignTable: 'messages');
     expect(
       res[0]['messages']!.length,

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -247,7 +247,7 @@ void main() {
     test('maybeSingle with 0 rows', () async {
       final user = await postgrest
           .from('users')
-          .select<PostgrestMapResponse?>()
+          .select<PostgrestMap?>()
           .eq('username', 'xxxxx')
           .maybeSingle();
       expect(user, isNull);

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -23,22 +23,23 @@ void main() {
   });
 
   test('order', () async {
-    final res = await postgrest.from('users').select().order('username');
+    final res =
+        await postgrest.from<PostgrestList>('users').select().order('username');
     expect(
-      ((res as List)[1] as Map)['username'],
+      res[1]['username'],
       'kiwicopple',
     );
-    expect(((res)[3] as Map)['username'], 'awailas');
+    expect(res[3]['username'], 'awailas');
   });
 
   test('order on multiple columns', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList>('users')
         .select()
         .order('status', ascending: true)
         .order('username');
     expect(
-      (res as List).map((row) => (row as Map)['status']),
+      res.map((row) => row['status']),
       [
         'ONLINE',
         'ONLINE',
@@ -47,7 +48,7 @@ void main() {
       ],
     );
     expect(
-      (res).map((row) => (row as Map)['username']),
+      res.map((row) => row['username']),
       [
         'supabot',
         'dragarcia',
@@ -59,13 +60,13 @@ void main() {
 
   test('order with filters on the same column', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestList>('users')
         .select()
         .gt('username', 'b')
         .lt('username', 'r')
         .order('username');
     expect(
-      (res as List).map((row) => (row as Map)['username']),
+      res.map((row) => row['username']),
       [
         'kiwicopple',
         'dragarcia',
@@ -74,8 +75,8 @@ void main() {
   });
 
   test("order on foreign table", () async {
-    final Map data = await postgrest
-        .from("users")
+    final data = await postgrest
+        .from<PostgrestMap>("users")
         .select(
           '''
           username,
@@ -107,13 +108,13 @@ void main() {
   });
 
   test('limit', () async {
-    final List res = await postgrest.from('users').select().limit(1);
-    expect((res).length, 1);
+    final res = await postgrest.from<PostgrestList>('users').select().limit(1);
+    expect(res.length, 1);
   });
 
   test("limit on foreign table", () async {
-    final Map data = await postgrest
-        .from("users")
+    final data = await postgrest
+        .from<PostgrestMap>("users")
         .select(
           '''
             username,
@@ -144,24 +145,26 @@ void main() {
   test('range', () async {
     const from = 1;
     const to = 3;
-    final res = await postgrest.from('users').select().range(from, to);
+    final res =
+        await postgrest.from<PostgrestList>('users').select().range(from, to);
     //from -1 so that the index is included
-    expect((res as List).length, to - (from - 1));
+    expect(res.length, to - (from - 1));
   });
 
   test('range 1-1', () async {
     const from = 1;
     const to = 1;
-    final res = await postgrest.from('users').select().range(from, to);
+    final res =
+        await postgrest.from<PostgrestList>('users').select().range(from, to);
     //from -1 so that the index is included
-    expect((res as List).length, to - (from - 1));
+    expect(res.length, to - (from - 1));
   });
 
   test("range on foreign table", () async {
     const from = 0;
     const to = 2;
-    final Map data = await postgrest
-        .from("users")
+    final data = await postgrest
+        .from<PostgrestMap>("users")
         .select(
           '''
             username,
@@ -186,8 +189,8 @@ void main() {
   test("range 1-1 on foreign table", () async {
     const from = 1;
     const to = 1;
-    final Map data = await postgrest
-        .from("users")
+    final data = await postgrest
+        .from<PostgrestMap>("users")
         .select(
           '''
             username,
@@ -212,28 +215,28 @@ void main() {
 
   test('single', () async {
     final res = await postgrest
-        .from('users')
+        .from<PostgrestMap>('users')
         .select()
         .eq('username', 'supabot')
         .single();
-    expect((res as Map)['username'], 'supabot');
-    expect((res)['status'], 'ONLINE');
+    expect(res['username'], 'supabot');
+    expect(res['status'], 'ONLINE');
   });
 
   group("maybe single", () {
     test('maybeSingle with 1 row', () async {
-      final Map<String, dynamic> user = await postgrest
-          .from('users')
+      final user = await postgrest
+          .from<PostgrestMap?>('users')
           .select()
           .eq('username', 'dragarcia')
           .maybeSingle();
       expect(user, isNotNull);
-      expect(user['username'], 'dragarcia');
+      expect(user?['username'], 'dragarcia');
     });
 
     test('maybeSingle with 0 row and force response', () async {
       final user = await postgrest
-          .from('users')
+          .from<PostgrestResponse>('users')
           .select("*", FetchOptions(forceResponse: true))
           .eq('username', 'xxxxx')
           .maybeSingle();
@@ -242,8 +245,8 @@ void main() {
     });
 
     test('maybeSingle with 0 rows', () async {
-      final Map<String, dynamic>? user = await postgrest
-          .from('users')
+      final user = await postgrest
+          .from<PostgrestMapResponse?>('users')
           .select()
           .eq('username', 'xxxxx')
           .maybeSingle();

--- a/test/transforms_test.dart
+++ b/test/transforms_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   test('order', () async {
     final res =
-        await postgrest.from<PostgrestList>('users').select().order('username');
+        await postgrest.from('users').select<PostgrestList>().order('username');
     expect(
       res[1]['username'],
       'kiwicopple',
@@ -34,8 +34,8 @@ void main() {
 
   test('order on multiple columns', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select()
+        .from('users')
+        .select<PostgrestList>()
         .order('status', ascending: true)
         .order('username');
     expect(
@@ -60,8 +60,8 @@ void main() {
 
   test('order with filters on the same column', () async {
     final res = await postgrest
-        .from<PostgrestList>('users')
-        .select()
+        .from('users')
+        .select<PostgrestList>()
         .gt('username', 'b')
         .lt('username', 'r')
         .order('username');
@@ -76,8 +76,8 @@ void main() {
 
   test("order on foreign table", () async {
     final data = await postgrest
-        .from<PostgrestMap>("users")
-        .select(
+        .from("users")
+        .select<PostgrestMap>(
           '''
           username,
           messages(
@@ -108,14 +108,14 @@ void main() {
   });
 
   test('limit', () async {
-    final res = await postgrest.from<PostgrestList>('users').select().limit(1);
+    final res = await postgrest.from('users').select<PostgrestList>().limit(1);
     expect(res.length, 1);
   });
 
   test("limit on foreign table", () async {
     final data = await postgrest
-        .from<PostgrestMap>("users")
-        .select(
+        .from("users")
+        .select<PostgrestMap>(
           '''
             username,
             messages(
@@ -146,7 +146,7 @@ void main() {
     const from = 1;
     const to = 3;
     final res =
-        await postgrest.from<PostgrestList>('users').select().range(from, to);
+        await postgrest.from('users').select<PostgrestList>().range(from, to);
     //from -1 so that the index is included
     expect(res.length, to - (from - 1));
   });
@@ -155,7 +155,7 @@ void main() {
     const from = 1;
     const to = 1;
     final res =
-        await postgrest.from<PostgrestList>('users').select().range(from, to);
+        await postgrest.from('users').select<PostgrestList>().range(from, to);
     //from -1 so that the index is included
     expect(res.length, to - (from - 1));
   });
@@ -164,8 +164,8 @@ void main() {
     const from = 0;
     const to = 2;
     final data = await postgrest
-        .from<PostgrestMap>("users")
-        .select(
+        .from("users")
+        .select<PostgrestMap>(
           '''
             username,
             messages(
@@ -190,8 +190,8 @@ void main() {
     const from = 1;
     const to = 1;
     final data = await postgrest
-        .from<PostgrestMap>("users")
-        .select(
+        .from("users")
+        .select<PostgrestMap>(
           '''
             username,
             messages(
@@ -215,8 +215,8 @@ void main() {
 
   test('single', () async {
     final res = await postgrest
-        .from<PostgrestMap>('users')
-        .select()
+        .from('users')
+        .select<PostgrestMap>()
         .eq('username', 'supabot')
         .single();
     expect(res['username'], 'supabot');
@@ -226,8 +226,8 @@ void main() {
   group("maybe single", () {
     test('maybeSingle with 1 row', () async {
       final user = await postgrest
-          .from<PostgrestMap?>('users')
-          .select()
+          .from('users')
+          .select<PostgrestMap?>()
           .eq('username', 'dragarcia')
           .maybeSingle();
       expect(user, isNotNull);
@@ -236,8 +236,8 @@ void main() {
 
     test('maybeSingle with 0 row and force response', () async {
       final user = await postgrest
-          .from<PostgrestResponse>('users')
-          .select("*", FetchOptions(forceResponse: true))
+          .from('users')
+          .select<PostgrestResponse>("*", FetchOptions(forceResponse: true))
           .eq('username', 'xxxxx')
           .maybeSingle();
       expect(user, isA<PostgrestResponse>());
@@ -246,8 +246,8 @@ void main() {
 
     test('maybeSingle with 0 rows', () async {
       final user = await postgrest
-          .from<PostgrestMapResponse?>('users')
-          .select()
+          .from('users')
+          .select<PostgrestMapResponse?>()
           .eq('username', 'xxxxx')
           .maybeSingle();
       expect(user, isNull);


### PR DESCRIPTION
The idea is to pass a type to ~~`from`~~ `select`, which sets the response type. I had to add another generic to `PostgrestBuilder` to properly type the converter. The type from `from` is used as parameter type for `converter`. This doesn't infer the type depending on `single` or `count`, but makes it easier to type if you know what you get. `insert`/`update`/`upsert`/`delete` now return `void` and need a `select` to change the type.

close https://github.com/supabase-community/supabase-flutter/issues/252