### PR TITLE
fix: calling  multiple times will override the previous select

### DIFF
--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -47,7 +47,7 @@ class PostgrestQueryBuilder extends PostgrestBuilder {
       return c;
     }).join();
 
-    appendSearchParams('select', cleanedColumns);
+    overrideSearchParams('select', cleanedColumns);
     _options = options;
     return PostgrestFilterBuilder(this);
   }

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -31,7 +31,7 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T> {
       return c;
     }).join();
 
-    appendSearchParams('select', cleanedColumns);
+    overrideSearchParams('select', cleanedColumns);
     if (_headers['Prefer'] != null) {
       _headers['Prefer'] = '${_headers['Prefer']},';
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, calling `.select()` on query builder will add `select=*` every single time it's being called resulting in a url like this:

```dart
supabase.from('').select().select().select();
```
results in:
```
/rest/v1/todos?select=%2A&select=%2A&select=%2A
```

This PR fixes this so that calling multiple .select() will just override each other resulting in a URL like this:
```
/rest/v1/todos?select=%2A
```
