### PR TITLE
fix: catch error return type fixed

### DIFF
--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -371,8 +371,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
   }
 
   @override
-  Future<T?> catchError(Function onError,
-      {bool Function(Object error)? test}) async {
+  Future<T> catchError(Function onError, {bool Function(Object error)? test}) {
     return then((value) => value).catchError(onError, test: test);
   }
 
@@ -440,7 +439,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
   }
 
   @override
-  Future<T?> timeout(Duration timeLimit, {FutureOr<T?> Function()? onTimeout}) {
+  Future<T> timeout(Duration timeLimit, {FutureOr<T> Function()? onTimeout}) {
     return then((value) => value).timeout(timeLimit, onTimeout: onTimeout);
   }
 


### PR DESCRIPTION
Changes in https://github.com/supabase-community/postgrest-dart/pull/97 caused some errors on my end.

<img width="854" alt="Screen Shot 2022-11-01 at 10 54 38" src="https://user-images.githubusercontent.com/18113850/199141715-3ec2f720-6163-4ae3-87a1-e70b75ade3cf.png">

Not sure why it didn't cause the tests to fail. Both the tests of stable dart branch of this PR and [this](https://github.com/supabase-community/postgrest-dart/pull/97) PR are passing, which seems weird. 