### PR TITLE
fix: make isolate optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## [1.2.1]
+
+- fix: remove the breaking change that was introduced in v1.2.0 [#103](https://github.com/supabase/postgrest-dart/pull/103)
+
 ## [1.2.0]
 
-- feat: use isolates only for huge JSON and reuse isolates [#90](https://github.com/supabase/postgrest-dart/pull/90)
+- BREAKING: use isolates only for huge JSON and reuse isolates [#90](https://github.com/supabase/postgrest-dart/pull/90)
 
 ## [1.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [1.2.0]
 
 - BREAKING: use isolates only for huge JSON and reuse isolates [#90](https://github.com/supabase/postgrest-dart/pull/90)
+  This breaking change has been removed in v1.2.1
 
 ## [1.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [1.2.0]
 
 - BREAKING: use isolates only for huge JSON and reuse isolates [#90](https://github.com/supabase/postgrest-dart/pull/90)
-  This breaking change has been removed in v1.2.1
+  * This breaking chnge has been removed in v1.2.1
 
 ## [1.1.1]
 

--- a/lib/src/postgrest_builder.dart
+++ b/lib/src/postgrest_builder.dart
@@ -33,7 +33,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
   late Uri _url;
   PostgrestConverter<T, S>? _converter;
   late final Client? _httpClient;
-  late final YAJsonIsolate _isolate;
+  late final YAJsonIsolate? _isolate;
   // ignore: prefer_final_fields
   FetchOptions? _options;
 
@@ -44,7 +44,7 @@ class PostgrestBuilder<T, S> implements Future<T> {
     String? method,
     dynamic body,
     Client? httpClient,
-    required YAJsonIsolate isolate,
+    YAJsonIsolate? isolate,
     FetchOptions? options,
   }) {
     _url = url;
@@ -212,8 +212,8 @@ class PostgrestBuilder<T, S> implements Future<T> {
           body = response.body;
         } else {
           try {
-            if ((response.contentLength ?? 0) > 10000) {
-              body = await _isolate.decode(response.body);
+            if ((response.contentLength ?? 0) > 10000 && _isolate != null) {
+              body = await _isolate!.decode(response.body);
             } else {
               body = jsonDecode(response.body);
             }

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -15,7 +15,7 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
     String? schema,
     Client? httpClient,
     FetchOptions? options,
-    required YAJsonIsolate isolate,
+    YAJsonIsolate? isolate,
   }) : super(
           url: Uri.parse(url),
           headers: headers ?? {},

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.2.0';
+const version = '1.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 1.2.0
+version: 1.2.1
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/postgrest-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove the breaking change that was introduced accidentally where `PostgrestQueryBuilder` now requires an isolate, which is breaking supabase-dart.