### PR TITLE
fix: `delete()` now does not return data by default and comments cleanup

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,4 @@ include: package:lints/recommended.yaml
 linter:
   rules:
     avoid_print: false 
+    public_member_api_docs: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,4 +3,3 @@ include: package:lints/recommended.yaml
 linter:
   rules:
     avoid_print: false 
-    public_member_api_docs: true

--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -15,7 +15,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows which doesn't satisfy the filter.
   ///
   /// ```dart
-  /// postgrest.from('users').select().not('status', 'eq', 'OFFLINE')
+  /// await supabase.from('users').select().not('status', 'eq', 'OFFLINE');
   /// ```
   PostgrestFilterBuilder<T> not(String column, String operator, dynamic value) {
     if (value is List) {
@@ -39,7 +39,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows satisfying at least one of the filters.
   ///
   /// ```dart
-  /// postgrest.from('users').select().or('status.eq.OFFLINE,username.eq.supabot')
+  /// await supabase.from('users').select().or('status.eq.OFFLINE,username.eq.supabot');
   /// ```
   PostgrestFilterBuilder<T> or(String filters, {String? foreignTable}) {
     final key = foreignTable != null ? '"$foreignTable".or' : 'or';
@@ -50,7 +50,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] exactly matches the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('users').select().eq('username', 'supabot')
+  /// await supabase.from('users').select().eq('username', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> eq(String column, dynamic value) {
     if (value is List) {
@@ -64,7 +64,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] doesn't match the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('users').select().neq('username', 'supabot')
+  /// await supabase.from('users').select().neq('username', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> neq(String column, dynamic value) {
     if (value is List) {
@@ -78,7 +78,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is greater than the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('messages').select().gt('id', 1)
+  /// await supabase.from('messages').select().gt('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gt(String column, dynamic value) {
     appendSearchParams(column, 'gt.$value');
@@ -88,7 +88,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is greater than or equal to the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('messages').select().gte('id', 1)
+  /// await supabase.from('messages').select().gte('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gte(String column, dynamic value) {
     appendSearchParams(column, 'gte.$value');
@@ -98,7 +98,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is less than the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('messages').select().lt('id', 2)
+  /// await supabase.from('messages').select().lt('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lt(String column, dynamic value) {
     appendSearchParams(column, 'lt.$value');
@@ -108,7 +108,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is less than or equal to the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('messages').select().lte('id', 2)
+  /// await supabase.from('messages').select().lte('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lte(String column, dynamic value) {
     appendSearchParams(column, 'lte.$value');
@@ -118,7 +118,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case sensitive).
   ///
   /// ```dart
-  /// postgrest.from('users').select().like('username', '%supa%')
+  /// await supabase.from('users').select().like('username', '%supa%');
   /// ```
   PostgrestFilterBuilder<T> like(String column, String pattern) {
     appendSearchParams(column, 'like.$pattern');
@@ -128,7 +128,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case insensitive).
   ///
   /// ```dart
-  /// postgrest.from('users').select().ilike('username', '%SUPA%')
+  /// await supabase.from('users').select().ilike('username', '%SUPA%');
   /// ```
   PostgrestFilterBuilder<T> ilike(String column, String pattern) {
     appendSearchParams(column, 'ilike.$pattern');
@@ -139,7 +139,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///
   /// Finds all rows whose value on the stated [column] exactly match the specified [value].
   /// ```dart
-  /// postgrest.from('users').select().is_('data', null)
+  /// await supabase.from('users').select().is_('data', null);
   /// ```
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> is_(String column, dynamic value) {
@@ -150,7 +150,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is found on the specified [values].
   ///
   /// ```dart
-  /// postgrest.from('users').select().in_('status', ['ONLINE', 'OFFLINE'])
+  /// await supabase.from('users').select().in_('status', ['ONLINE', 'OFFLINE']);
   /// ```
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> in_(String column, List values) {
@@ -161,7 +161,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose json, array, or range value on the stated [column] contains the values specified in [value].
   ///
   /// ```dart
-  /// postgrest.from('users').select().contains('age_range', '[1,2)')
+  /// await supabase.from('users').select().contains('age_range', '[1,2)');
   /// ```
   PostgrestFilterBuilder<T> contains(String column, dynamic value) {
     if (value is String) {
@@ -181,7 +181,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose json, array, or range value on the stated [column] is contained by the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('users').select().containedBy('age_range', '[1,2)')
+  /// await supabase.from('users').select().containedBy('age_range', '[1,2)');
   /// ```
   PostgrestFilterBuilder<T> containedBy(String column, dynamic value) {
     if (value is String) {
@@ -201,7 +201,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] is strictly to the left of the specified [range].
   ///
   /// ```dart
-  /// postgrest.from('users').select().sl('age_range', '[2,25)')
+  /// await supabase.from('users').select().sl('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLt(String column, String range) {
     appendSearchParams(column, 'sl.$range');
@@ -211,7 +211,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] is strictly to the right of the specified [range].
   ///
   /// ```dart
-  /// postgrest.from('users').select().rangeGt('age_range', '[2,25)')
+  /// await supabase.from('users').select().rangeGt('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGt(String column, String range) {
     appendSearchParams(column, 'sr.$range');
@@ -221,7 +221,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] does not extend to the left of the specified [range].
   ///
   /// ```dart
-  /// postgrest.from('users').select().rangeGte('age_range', '[2,25)')
+  /// await supabase.from('users').select().rangeGte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGte(String column, String range) {
     appendSearchParams(column, 'nxl.$range');
@@ -231,7 +231,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] does not extend to the right of the specified [range].
   ///
   /// ```dart
-  /// postgrest.from('users').select().rangeLte('age_range', '[2,25)')
+  /// await supabase.from('users').select().rangeLte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLte(String column, String range) {
     appendSearchParams(column, 'nxr.$range');
@@ -241,7 +241,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] is adjacent to the specified [range].
   ///
   /// ```dart
-  /// postgrest.from('users').select().rangeAdjacent('age_range', '[2,25)')
+  /// await supabase.from('users').select().rangeAdjacent('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeAdjacent(String column, String range) {
     appendSearchParams(column, 'adj.$range');
@@ -251,7 +251,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose array or range value on the stated [column] overlaps (has a value in common) with the specified [value].
   ///
   /// ```dart
-  /// postgrest.from('users').select().overlaps('age_range', '[2,25)')
+  /// await supabase.from('users').select().overlaps('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> overlaps(String column, dynamic value) {
     if (value is String) {
@@ -268,7 +268,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose text or tsvector value on the stated [column] matches the tsquery in [query].
   ///
   /// ```dart
-  /// postgrest.from('users').select().textSearch('catchphrase', "'fat' & 'cat'", config: 'english')
+  /// await supabase.from('users').select().textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
   /// ```
   PostgrestFilterBuilder<T> textSearch(
     String column,
@@ -296,7 +296,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose [column] satisfies the filter.
   ///
   /// ```dart
-  /// postgrest.from('users').select().filter('username', 'eq', 'supabot')
+  /// await supabase.from('users').select().filter('username', 'eq', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> filter(
       String column, String operator, dynamic value) {
@@ -322,7 +322,7 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///
   /// [query] contains column names as keys mapped to their filter values.
   /// ```dart
-  /// postgrest.from('users').select().match({'username': 'supabot', 'status': 'ONLINE'})
+  /// await supabase.from('users').select().match({'username': 'supabot', 'status': 'ONLINE'});
   /// ```
   PostgrestFilterBuilder<T> match(Map query) {
     query.forEach((k, v) => appendSearchParams('$k', 'eq.$v'));

--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -15,7 +15,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows which doesn't satisfy the filter.
   ///
   /// ```dart
-  /// await supabase.from('users').select().not('status', 'eq', 'OFFLINE');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .not('status', 'eq', 'OFFLINE');
   /// ```
   PostgrestFilterBuilder<T> not(String column, String operator, dynamic value) {
     if (value is List) {
@@ -39,7 +42,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows satisfying at least one of the filters.
   ///
   /// ```dart
-  /// await supabase.from('users').select().or('status.eq.OFFLINE,username.eq.supabot');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .or('status.eq.OFFLINE,username.eq.supabot');
   /// ```
   PostgrestFilterBuilder<T> or(String filters, {String? foreignTable}) {
     final key = foreignTable != null ? '"$foreignTable".or' : 'or';
@@ -50,7 +56,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] exactly matches the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('users').select().eq('username', 'supabot');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .eq('username', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> eq(String column, dynamic value) {
     if (value is List) {
@@ -64,7 +73,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] doesn't match the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('users').select().neq('username', 'supabot');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .neq('username', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> neq(String column, dynamic value) {
     if (value is List) {
@@ -78,7 +90,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is greater than the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('messages').select().gt('id', 1);
+  /// await supabase
+  ///     .from('messages')
+  ///     .select()
+  ///     .gt('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gt(String column, dynamic value) {
     appendSearchParams(column, 'gt.$value');
@@ -88,7 +103,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is greater than or equal to the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('messages').select().gte('id', 1);
+  /// await supabase
+  ///     .from('messages')
+  ///     .select()
+  ///     .gte('id', 1);
   /// ```
   PostgrestFilterBuilder<T> gte(String column, dynamic value) {
     appendSearchParams(column, 'gte.$value');
@@ -98,7 +116,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is less than the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('messages').select().lt('id', 2);
+  /// await supabase
+  ///     .from('messages')
+  ///     .select()
+  ///     .lt('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lt(String column, dynamic value) {
     appendSearchParams(column, 'lt.$value');
@@ -108,7 +129,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is less than or equal to the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('messages').select().lte('id', 2);
+  /// await supabase
+  ///     .from('messages')
+  ///     .select()
+  ///     .lte('id', 2);
   /// ```
   PostgrestFilterBuilder<T> lte(String column, dynamic value) {
     appendSearchParams(column, 'lte.$value');
@@ -118,7 +142,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case sensitive).
   ///
   /// ```dart
-  /// await supabase.from('users').select().like('username', '%supa%');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .like('username', '%supa%');
   /// ```
   PostgrestFilterBuilder<T> like(String column, String pattern) {
     appendSearchParams(column, 'like.$pattern');
@@ -128,7 +155,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value in the stated [column] matches the supplied [pattern] (case insensitive).
   ///
   /// ```dart
-  /// await supabase.from('users').select().ilike('username', '%SUPA%');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .ilike('username', '%SUPA%');
   /// ```
   PostgrestFilterBuilder<T> ilike(String column, String pattern) {
     appendSearchParams(column, 'ilike.$pattern');
@@ -139,7 +169,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///
   /// Finds all rows whose value on the stated [column] exactly match the specified [value].
   /// ```dart
-  /// await supabase.from('users').select().is_('data', null);
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .is_('data', null);
   /// ```
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> is_(String column, dynamic value) {
@@ -150,7 +183,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose value on the stated [column] is found on the specified [values].
   ///
   /// ```dart
-  /// await supabase.from('users').select().in_('status', ['ONLINE', 'OFFLINE']);
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .in_('status', ['ONLINE', 'OFFLINE']);
   /// ```
   // ignore: non_constant_identifier_names
   PostgrestFilterBuilder<T> in_(String column, List values) {
@@ -161,7 +197,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose json, array, or range value on the stated [column] contains the values specified in [value].
   ///
   /// ```dart
-  /// await supabase.from('users').select().contains('age_range', '[1,2)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .contains('age_range', '[1,2)');
   /// ```
   PostgrestFilterBuilder<T> contains(String column, dynamic value) {
     if (value is String) {
@@ -181,7 +220,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose json, array, or range value on the stated [column] is contained by the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('users').select().containedBy('age_range', '[1,2)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .containedBy('age_range', '[1,2)');
   /// ```
   PostgrestFilterBuilder<T> containedBy(String column, dynamic value) {
     if (value is String) {
@@ -201,7 +243,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] is strictly to the left of the specified [range].
   ///
   /// ```dart
-  /// await supabase.from('users').select().sl('age_range', '[2,25)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .sl('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLt(String column, String range) {
     appendSearchParams(column, 'sl.$range');
@@ -211,7 +256,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] is strictly to the right of the specified [range].
   ///
   /// ```dart
-  /// await supabase.from('users').select().rangeGt('age_range', '[2,25)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .rangeGt('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGt(String column, String range) {
     appendSearchParams(column, 'sr.$range');
@@ -221,7 +269,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] does not extend to the left of the specified [range].
   ///
   /// ```dart
-  /// await supabase.from('users').select().rangeGte('age_range', '[2,25)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .rangeGte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeGte(String column, String range) {
     appendSearchParams(column, 'nxl.$range');
@@ -231,7 +282,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] does not extend to the right of the specified [range].
   ///
   /// ```dart
-  /// await supabase.from('users').select().rangeLte('age_range', '[2,25)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .rangeLte('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeLte(String column, String range) {
     appendSearchParams(column, 'nxr.$range');
@@ -241,7 +295,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose range value on the stated [column] is adjacent to the specified [range].
   ///
   /// ```dart
-  /// await supabase.from('users').select().rangeAdjacent('age_range', '[2,25)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .rangeAdjacent('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> rangeAdjacent(String column, String range) {
     appendSearchParams(column, 'adj.$range');
@@ -251,7 +308,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose array or range value on the stated [column] overlaps (has a value in common) with the specified [value].
   ///
   /// ```dart
-  /// await supabase.from('users').select().overlaps('age_range', '[2,25)');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .overlaps('age_range', '[2,25)');
   /// ```
   PostgrestFilterBuilder<T> overlaps(String column, dynamic value) {
     if (value is String) {
@@ -268,7 +328,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose text or tsvector value on the stated [column] matches the tsquery in [query].
   ///
   /// ```dart
-  /// await supabase.from('users').select().textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .textSearch('catchphrase', "'fat' & 'cat'", config: 'english');
   /// ```
   PostgrestFilterBuilder<T> textSearch(
     String column,
@@ -296,7 +359,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   /// Finds all rows whose [column] satisfies the filter.
   ///
   /// ```dart
-  /// await supabase.from('users').select().filter('username', 'eq', 'supabot');
+  /// await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .filter('username', 'eq', 'supabot');
   /// ```
   PostgrestFilterBuilder<T> filter(
       String column, String operator, dynamic value) {
@@ -322,7 +388,10 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   ///
   /// [query] contains column names as keys mapped to their filter values.
   /// ```dart
-  /// await supabase.from('users').select().match({'username': 'supabot', 'status': 'ONLINE'});
+  /// await supabase.from('users').select().match({
+  ///   'username': 'supabot',
+  ///   'status': 'ONLINE',
+  /// });
   /// ```
   PostgrestFilterBuilder<T> match(Map query) {
     query.forEach((k, v) => appendSearchParams('$k', 'eq.$v'));

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -1,5 +1,6 @@
 part of 'postgrest_builder.dart';
 
+/// {@template postgrest_query_builder}
 /// The query builder class provides a convenient interface to creating request queries.
 ///
 /// Allows the user to stack the filter functions before they call any of
@@ -8,7 +9,9 @@ part of 'postgrest_builder.dart';
 /// * update() - "patch"
 /// * delete() - "delete"
 /// Once any of these are called the filters are passed down to the Request.
+/// /// {@endtemplate}
 class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
+  /// {@macro postgrest_query_builder}
   PostgrestQueryBuilder(
     String url, {
     Map<String, String>? headers,
@@ -93,12 +96,17 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// Default (not returning data):
   /// ```dart
-  /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1})
+  /// await supabase.from('messages').insert(
+  ///     {'message': 'foo', 'username': 'supabot', 'channel_id': 1});
   /// ```
   ///
   /// Returning data:
   /// ```dart
-  /// postgrest.from('messages').insert({'message': 'foo', 'username': 'supabot', 'channel_id': 1}).select()
+  /// final data = await supabase.from('messages').insert({
+  ///   'message': 'foo',
+  ///   'username': 'supabot',
+  ///   'channel_id': 1
+  /// }).select();
   /// ```
   PostgrestFilterBuilder<T> insert(dynamic values) {
     _method = METHOD_POST;
@@ -111,8 +119,26 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// By specifying the [onConflict] query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
   /// [ignoreDuplicates] Specifies if duplicate rows should be ignored and not inserted.
+  ///
+  /// By default no data is returned. Use a trailing `select` to return data.
+  ///
+  /// Default (not returning data):
   /// ```dart
-  /// postgrest.from('messages').upsert({'id': 3, message: 'foo', 'username': 'supabot', 'channel_id': 2})
+  /// await supabase.from('messages').upsert({
+  ///   'id': 3,
+  ///   'message': 'foo',
+  ///   'username': 'supabot',
+  ///   'channel_id': 2
+  /// });
+  /// ```
+  ///
+  /// Returning data:
+  /// ```dart
+  /// final data = await supabase.from('messages').upsert({
+  ///   'message': 'foo',
+  ///   'username': 'supabot',
+  ///   'channel_id': 1
+  /// }).select();
   /// ```
   PostgrestFilterBuilder<T> upsert(
     dynamic values, {
@@ -138,8 +164,23 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
 
   /// Performs an UPDATE on the table.
   ///
+  /// By default no data is returned. Use a trailing `select` to return data.
+  ///
+  /// Default (not returning data):
   /// ```dart
-  /// postgrest.from('messages').update({'channel_id': 2}).eq('message', 'foo')
+  /// await supabase
+  ///     .from('messages')
+  ///     .update({'channel_id': 2})
+  ///     .eq('message', 'foo');
+  /// ```
+  ///
+  /// Returning data:
+  /// ```dart
+  /// await supabase
+  ///     .from('messages')
+  ///     .update({'channel_id': 2})
+  ///     .eq('message', 'foo')
+  ///     .select();
   /// ```
   PostgrestFilterBuilder<T> update(
     Map values, {
@@ -154,16 +195,29 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
 
   /// Performs a DELETE on the table.
   ///
-  /// By default the deleted record(s) will be returned. Set [returning] to minimal if you don't need this value.
+  /// By default no data is returned. Use a trailing `select` to return data.
+  ///
+  /// Default (not returning data):
   /// ```dart
-  /// postgrest.from('messages').delete().eq('message', 'foo')
+  /// await supabase
+  ///     .from('messages')
+  ///     .delete()
+  ///     .eq('message', 'foo');
+  /// ```
+  ///
+  /// Returning data:
+  /// ```dart
+  /// await supabase
+  ///     .from('messages')
+  ///     .delete()
+  ///     .eq('message', 'foo')
+  ///     .select();
   /// ```
   PostgrestFilterBuilder<T> delete({
-    ReturningOption returning = ReturningOption.representation,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_DELETE;
-    _headers['Prefer'] = 'return=${returning.name()}';
+    _headers['Prefer'] = '';
     _options = options.ensureNotHead();
     return PostgrestFilterBuilder<T>(this);
   }

--- a/lib/src/postgrest_query_builder.dart
+++ b/lib/src/postgrest_query_builder.dart
@@ -214,6 +214,8 @@ class PostgrestQueryBuilder<T> extends PostgrestBuilder<T, T> {
   ///     .select();
   /// ```
   PostgrestFilterBuilder<T> delete({
+    @Deprecated('Append `.select()` on the query instead')
+        ReturningOption returning = ReturningOption.representation,
     FetchOptions options = const FetchOptions(),
   }) {
     _method = METHOD_DELETE;

--- a/lib/src/postgrest_transform_builder.dart
+++ b/lib/src/postgrest_transform_builder.dart
@@ -79,10 +79,19 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// When [options] has `ascending` value true, the result will be in ascending order.
   /// When [options] has `nullsFirst` value true, `null`s appear first.
+  /// ```dart
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select()
+  ///     .order('username', ascending: false);
+  /// ````
   /// If [column] is a foreign column, the [options] need to have `foreignTable` value provided
   /// ```dart
-  /// postgrest.from('users').select().order('username', ascending: false)
-  /// postgrest.from('users').select('messages(*)').order('channel_id', foreignTable: 'messages', ascending: false)
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select('messages(*)')
+  ///     .order('channel_id',
+  ///         foreignTable: 'messages', ascending: false);
   /// ```
   PostgrestTransformBuilder<T> order(
     String column, {
@@ -101,10 +110,16 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
 
   /// Limits the result with the specified `count`.
   ///
+  /// ```dart
+  /// final data = await supabase.from('users').select().limit(1);
+  /// ```
+  ///
   /// If we want to limit a foreign column, the [options] need to have `foreignTable` value provided
   /// ```dart
-  /// postgrest.from('users').select().limit(1)
-  /// postgrest.from('users').select('messages(*)').limit(1, foreignTable: 'messages')
+  /// final data = await supabase
+  ///   .from('users')
+  ///   .select('messages(*)')
+  ///   .limit(1, foreignTable: 'messages');
   /// ```
   PostgrestTransformBuilder<T> limit(int count, {String? foreignTable}) {
     final key = foreignTable == null ? 'limit' : '$foreignTable.limit';
@@ -115,9 +130,19 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
 
   /// Limits the result to rows within the specified range, inclusive.
   ///
+  /// ```dart
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select('messages(*)')
+  ///     .range(1, 1);
+  /// ```
+  ///
   /// If we want to limit a foreign column, the [options] need to have `foreignTable` value provided
   /// ```dart
-  /// postgrest.from('users').select('messages(*)').range(1, 1, foreignTable: 'messages')
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select('messages(*)')
+  ///     .range(1, 1, foreignTable: 'messages');
   /// ```
   PostgrestTransformBuilder<T> range(int from, int to, {String? foreignTable}) {
     final keyOffset = foreignTable == null ? 'offset' : '$foreignTable.offset';
@@ -132,7 +157,11 @@ class PostgrestTransformBuilder<T> extends PostgrestBuilder<T, T> {
   ///
   /// Result must be one row (e.g. using `limit`), otherwise this will result in an error.
   /// ```dart
-  /// postgrest.from('users').select<PostgrestMap>().limit(1).single()
+  /// final data = await supabase
+  ///     .from('users')
+  ///     .select<PostgrestMap>()
+  ///     .limit(1)
+  ///     .single();
   /// ```
   ///
   /// Data type is `Map<String, dynamic>`.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -105,11 +105,30 @@ extension TextSearchTypeName on TextSearchType {
   }
 }
 
+/// {@template fetch_options}
+/// Options for querying Supabase.
+///
+/// [count] options can be used to retrieve the total number of rows that satisfies the
+/// query. The value for count respects any filters (e.g. `eq`, `gt`), but ignores
+/// modifiers (e.g. `limit`, `range`).
+///
+/// Set [head] to `true` if you only want the [count] value and not the underlying data.
+///
+/// Set [forceResponse] to `true` if you want to force the return type to be [PostgrestResponse<T>].
+/// {endtemplate}
 class FetchOptions {
+  /// Set [head] to true if you only want the [count] value and not the underlying data.
   final bool head;
+
+  /// [count] options can be used to retrieve the total number of rows that satisfies the
+  /// query. The value for count respects any filters (e.g. eq, gt), but ignores
+  /// modifiers (e.g. limit, range).
   final CountOption? count;
+
+  /// Set [forceResponse] to `true` if you want to force the return type to be [PostgrestResponse<T>].
   final bool forceResponse;
 
+  /// {@macro fetch_options}
   const FetchOptions({
     this.head = false,
     this.count,


### PR DESCRIPTION
While I was cleaning up the comments, I noticed that `delete()` still returns the deleted value by default. I have updated the code so that it does not return value by default.

- `delete()` now does not return data by default
- clean up the comments