### PR TITLE
fix: don't change client's headers per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.3]
+
+- fix: deprecate `auth()`, use `setAuth()` instead [#107](https://github.com/supabase/postgrest-dart/pull/107)
+- fix: requests don't affect client's headers [#107](https://github.com/supabase/postgrest-dart/pull/107)
+
 ## [1.2.2]
 
 - fix: deprecate `returning` parameter of `.delete()` [#105](https://github.com/supabase/postgrest-dart/pull/105)

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -44,7 +44,7 @@ class PostgrestClient {
     final url = '${this.url}/$table';
     return PostgrestQueryBuilder<void>(
       url,
-      headers: headers,
+      headers: {...headers},
       schema: schema,
       httpClient: httpClient,
       isolate: _isolate,
@@ -64,7 +64,7 @@ class PostgrestClient {
     final url = '${this.url}/rpc/$fn';
     return PostgrestRpcBuilder(
       url,
-      headers: headers,
+      headers: {...headers},
       schema: schema,
       httpClient: httpClient,
       options: options,

--- a/lib/src/postgrest.dart
+++ b/lib/src/postgrest.dart
@@ -34,8 +34,18 @@ class PostgrestClient {
         _hasCustomIsolate = isolate != null;
 
   /// Authenticates the request with JWT.
+  @Deprecated("Use setAuth() instead")
   PostgrestClient auth(String token) {
     headers['Authorization'] = 'Bearer $token';
+    return this;
+  }
+
+  PostgrestClient setAuth(String? token) {
+    if (token != null) {
+      headers['Authorization'] = 'Bearer $token';
+    } else {
+      headers.remove('Authorization');
+    }
     return this;
   }
 

--- a/lib/src/postgrest_filter_builder.dart
+++ b/lib/src/postgrest_filter_builder.dart
@@ -336,7 +336,6 @@ class PostgrestFilterBuilder<T> extends PostgrestTransformBuilder<T> {
   PostgrestFilterBuilder<T> textSearch(
     String column,
     String query, {
-
     /// The text search configuration to use.
     String? config,
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.2.2';
+const version = '1.2.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgrest
 description: PostgREST client for Dart. This library provides an ORM interface to PostgREST.
-version: 1.2.2
+version: 1.2.3
 homepage: 'https://supabase.com'
 repository: 'https://github.com/supabase/postgrest-dart'
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -100,12 +100,16 @@ void main() {
     });
 
     test('upsert', () async {
+      final headersBefore = {...postgrest.headers};
       final res = await postgrest.from('messages').upsert({
         'id': 3,
         'message': 'foo',
         'username': 'supabot',
         'channel_id': 2
       }).select<PostgrestList>();
+      final headersAfter = {...postgrest.headers};
+
+      expect(headersBefore, headersAfter);
       expect(res.first['id'], 3);
 
       final resMsg = await postgrest.from('messages').select<PostgrestList>();

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -75,7 +75,7 @@ void main() {
     });
 
     test('auth', () async {
-      postgrest = PostgrestClient(rootUrl).auth('foo');
+      postgrest = PostgrestClient(rootUrl).setAuth('foo');
       expect(
         postgrest.headers['Authorization'],
         'Bearer foo',


### PR DESCRIPTION
Currently , when doing a request, which modifies the headers (like upsert), the headers of the client get changed. I'm now copying the headers to prevent that.

In addition I'm deprecating `auth()` in favor of `setAuth()` to align to the other libs.